### PR TITLE
Support Handler<@Options> and Handler<AsyncResult<@Options>>

### DIFF
--- a/src/main/resources/vertx-groovy/template/groovy.templ
+++ b/src/main/resources/vertx-groovy/template/groovy.templ
@@ -159,7 +159,7 @@ this.delegate
 	@else{param.type.kind == CLASS_HANDLER}
 		@code{eventType=param.type.args[0]}
 		@code{eventKind=eventType.kind}
-		@if{eventKind == CLASS_OTHER || eventKind.basic || eventKind == CLASS_VOID || eventKind == CLASS_THROWABLE}
+		@if{eventKind == CLASS_OTHER || eventKind.basic || eventKind == CLASS_VOID || eventKind == CLASS_THROWABLE || eventKind == CLASS_OPTIONS}
 			@{param.name}
 		@else{eventKind == CLASS_JSON_OBJECT}
 			new Handler<JsonObject>() {\n
@@ -209,7 +209,7 @@ this.delegate
 		@else{eventKind == CLASS_ASYNC_RESULT}
 			@code{resultType=eventType.args[0]}
 			@code{resultKind=resultType.kind}
-			@if{resultKind == CLASS_OTHER || resultKind.basic || resultKind == CLASS_VOID}
+			@if{resultKind == CLASS_OTHER || resultKind.basic || resultKind == CLASS_VOID || resultKind == CLASS_OPTIONS}
 				@{param.name}
 			@else{resultKind == CLASS_LIST || resultKind == CLASS_SET}
 				@code{elementType=resultType.args[0]}

--- a/src/test/groovy/io/vertx/lang/groovy/ApiTest.groovy
+++ b/src/test/groovy/io/vertx/lang/groovy/ApiTest.groovy
@@ -18,6 +18,7 @@ package io.vertx.lang.groovy
 import io.vertx.codegen.testmodel.RefedInterface1Impl
 import io.vertx.codegen.testmodel.TestEnum
 import io.vertx.codegen.testmodel.TestInterfaceImpl
+import io.vertx.codegen.testmodel.TestOptions
 import io.vertx.core.AsyncResult
 import io.vertx.core.VertxException
 import io.vertx.groovy.codegen.testmodel.GenericRefedInterface
@@ -127,6 +128,40 @@ public class ApiTest {
   @Test
   public void testNullOptionsParam() {
     obj.methodWithNullOptionsParam(null);
+  }
+
+  @Test
+  public void testMethodWithHandlerOptions() {
+    def options = new TestOptions()
+    options.foo = "foo"
+    options.bar = 123
+    def count = 0
+    obj.methodWithHandlerOptions({
+      assertEquals(options.foo, it.foo)
+      assertEquals(options.bar, it.bar)
+      //assertNull(it.wibble)
+      count++
+    })
+    assertEquals(1, count)
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultOptions() {
+    def options = new TestOptions()
+    options.foo = "foo"
+    options.bar = 123
+    def checker = new AsyncResultChecker()
+    obj.methodWithHandlerAsyncResultOptions(false, { result ->
+      assertTrue(result.succeeded())
+      assertFalse(result.failed())
+      def res = result.result()
+      assertEquals(options.foo, res.foo)
+      assertEquals(options.bar, res.bar)
+      assertNull(result.cause())
+      checker.count++
+    })
+    obj.methodWithHandlerAsyncResultOptions(true, { checker.assertAsyncFailure("foobar!", it) })
+    assertEquals(2, checker.count);
   }
 
   @Test


### PR DESCRIPTION
Like JavaScript, the `assertNull(it.wibble)` won't work as `wibble` and `bar` in `TestOptions` are primitives and not boxed types.
