### PR TITLE
Perform wrapObject recursively on JsonObject and JsonArray

### DIFF
--- a/src/main/groovy/io/vertx/lang/groovy/InternalHelper.groovy
+++ b/src/main/groovy/io/vertx/lang/groovy/InternalHelper.groovy
@@ -44,9 +44,13 @@ public class InternalHelper {
 
   public static Object wrapObject(Object obj) {
     if (obj instanceof JsonObject) {
-      return ((JsonObject) obj).getMap();
+      return ((JsonObject) obj).getMap().collectEntries { k, v ->
+        [k, wrapObject(v)]
+      }
     } else if (obj instanceof JsonArray) {
-      return ((JsonArray) obj).toList();
+      return ((JsonArray) obj).toList().collect {
+        wrapObject(it)
+      }
     } else if (obj instanceof io.vertx.core.buffer.Buffer) {
       return new Buffer((io.vertx.core.buffer.Buffer) obj);
     }

--- a/src/test/groovy/io/vertx/lang/groovy/InternalHelperTest.groovy
+++ b/src/test/groovy/io/vertx/lang/groovy/InternalHelperTest.groovy
@@ -1,0 +1,30 @@
+package io.vertx.lang.groovy
+
+import static org.junit.Assert.*;
+
+import io.vertx.core.json.JsonArray
+import io.vertx.core.json.JsonObject
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:smfitts@gmail.com">Sean Fitts</a>
+ */
+class InternalHelperTest {
+  /**
+   * Confirm that when we convert to map/list form we do so recursively.
+   */
+  @Test
+  void testWrapObject() {
+    // Create a JsonObject with nested JsonObject and JsonArray values
+    def obj = new JsonObject()
+      .put('nestedObj', new JsonObject().put('key', 'value'))
+      .put('nestedList', new JsonArray().add(new JsonObject().put('key', 'value')))
+      
+    // Get the wrapped form and confirm that it acted recursively
+    Map<String, Object> wrapped = InternalHelper.wrapObject(obj)
+    assertTrue(wrapped.get('nestedObj') instanceof Map)
+    List<Object> theList = wrapped.get('nestedList')
+    assertTrue(theList instanceof List)
+    assertTrue(theList.getAt(0) instanceof Map)
+  }
+}


### PR DESCRIPTION
Currently when we call wrapObject it applies to only the initial JsonObject/JsonArray.  This means that if there are nested JsonObject or JsonArray instances in the object graph they won't get converted.  This can lead to issues later on when Groovy code assumes it is dealing with only its native Json form (map/list).  This changes applies the conversion recursively.