### PR TITLE
Property is really called *timeout* in the code, and when using it in…

### DIFF
--- a/src/main/asciidoc/cheatsheet/DeliveryOptions.adoc
+++ b/src/main/asciidoc/cheatsheet/DeliveryOptions.adoc
@@ -13,7 +13,7 @@
 |===
 ^|Name | Type ^| Description
 
-|[[sendTimeout]]`sendTimeout`
+|[[timeout]]`timeout`
 |`Number`
 |+++
 Set the send timeout.+++


### PR DESCRIPTION
… a groovy Map, using 'sendTimeout' will have no effect (and even worse, no error reported)