### PR TITLE
Update templates to use wrapObject when converting JsonObject/JsonArray

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -273,7 +273,7 @@ blocking APIs safely within a Vert.x application.
 As discussed before, you can't call blocking operations directly from an event loop, as that would prevent it
 from doing any other useful work. So how can you do this?
 
-It's done by calling `link:groovydoc/io/vertx/groovy/core/Vertx.html#executeBlocking(io.vertx.core.Handler,%20io.vertx.core.Handler)[executeBlocking]` specifying both the blocking code to execute and a
+It's done by calling `link:groovydoc/io/vertx/groovy/core/Vertx.html#executeBlocking(io.vertx.core.Handler,%20boolean,%20io.vertx.core.Handler)[executeBlocking]` specifying both the blocking code to execute and a
 result handler to be called back asynchronous when the blocking code has been executed.
 
 [source,groovy]
@@ -290,7 +290,16 @@ vertx.executeBlocking({ future ->
 
 ----
 
+By default, if executeBlocking is called several times from the same context (e.g. the same verticle instance) then
+the different executeBlocking are executed _serially_ (i.e. one after another).
+
+If you don't care about ordering you can call `link:groovydoc/io/vertx/groovy/core/Vertx.html#executeBlocking(io.vertx.core.Handler,%20boolean,%20io.vertx.core.Handler)[executeBlocking]`
+specifying `false` as the argument to `ordered`. In this case any executeBlocking may be executed in parallel
+on the worker pool.
+
 An alternative way to run blocking code is to use a <<worker_verticles, worker verticle>>
+
+A worker verticle is always executed with a thread from the worker pool.
 
 == Verticles
 

--- a/src/main/groovy/io/vertx/groovy/core/Context.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/Context.groovy
@@ -112,7 +112,7 @@ public class Context {
    * @return the configuration of the deployment or null if not a Verticle deployment
    */
   public Map<String, Object> config() {
-    def ret = this.delegate.config()?.getMap();
+    def ret = (Map<String, Object>)InternalHelper.wrapObject(this.delegate.config());
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/Vertx.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/Vertx.groovy
@@ -425,7 +425,30 @@ public class Vertx implements Measured {
    * the handler should call the {@link io.vertx.groovy.core.Future#complete} or {@link io.vertx.groovy.core.Future#complete} method, or the {@link io.vertx.groovy.core.Future#fail}
    * method if it failed.
    * @param blockingCodeHandler handler representing the blocking code to run
+   * @param ordered if true then if executeBlocking is called several times on the same context, the executions for that context will be executed serially, not in parallel. if false then they will be no ordering guarantees
    * @param resultHandler handler that will be called when the blocking code is complete
+   */
+  public <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> resultHandler) {
+    this.delegate.executeBlocking(new Handler<io.vertx.core.Future<java.lang.Object>>() {
+      public void handle(io.vertx.core.Future<java.lang.Object> event) {
+        blockingCodeHandler.handle(new io.vertx.groovy.core.Future(event));
+      }
+    }, ordered, new Handler<AsyncResult<Object>>() {
+      public void handle(AsyncResult<Object> event) {
+        AsyncResult<Object> f
+        if (event.succeeded()) {
+          f = InternalHelper.<Object>result(InternalHelper.wrapObject(event.result()))
+        } else {
+          f = InternalHelper.<Object>failure(event.cause())
+        }
+        resultHandler.handle(f)
+      }
+    });
+  }
+  /**
+   * Like {@link io.vertx.groovy.core.Vertx#executeBlocking} called with ordered = true.
+   * @param blockingCodeHandler 
+   * @param resultHandler 
    */
   public <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, Handler<AsyncResult<T>> resultHandler) {
     this.delegate.executeBlocking(new Handler<io.vertx.core.Future<java.lang.Object>>() {

--- a/src/main/resources/vertx-groovy/template/classbody.templ
+++ b/src/main/resources/vertx-groovy/template/classbody.templ
@@ -44,16 +44,16 @@
 		    def ret = (@{method.returnType.simpleName}) InternalHelper.wrapObject(@includeNamed{'invokeDelegate';method=method});\n
 		@else{method.returnType.kind == CLASS_JSON_OBJECT}
 			@code{cachedType='Map<String, Object>'}
-		    def ret = @includeNamed{'invokeDelegate';method=method}?.getMap();\n
+		    def ret = (Map<String, Object>)InternalHelper.wrapObject(@includeNamed{'invokeDelegate';method=method});\n
 		@else{method.returnType.kind == CLASS_JSON_ARRAY}
 			@code{cachedType='List<Object>'}
-		    def ret = @includeNamed{'invokeDelegate';method=method}?.getList();\n
+		    def ret = (List<Object>)InternalHelper.wrapObject(@includeNamed{'invokeDelegate';method=method});\n
 		@else{method.returnType.kind == CLASS_LIST}
 			@code{cachedType=method.returnType.name}
 			@if{method.returnType.args[0].kind == CLASS_JSON_OBJECT}
-		    def ret = @includeNamed{'invokeDelegate';method=method}?.collect({underpants -> underpants.getMap()});\n
+		    def ret = @includeNamed{'invokeDelegate';method=method}?.collect({underpants -> InternalHelper.wrapObject(underpants)});\n
 			@else{method.returnType.args[0].kind == CLASS_JSON_ARRAY}
-		    def ret = @includeNamed{'invokeDelegate';method=method}?.collect({underpants -> underpants.getList()});\n
+		    def ret = @includeNamed{'invokeDelegate';method=method}?.collect({underpants -> InternalHelper.wrapObject(underpants)});\n
 			@else{method.returnType.args[0].kind == CLASS_API}
 		    def ret = @includeNamed{'invokeDelegate';method=method}?.collect({underpants -> @{genConstructor(method.returnType.args[0], "underpants")}});\n
 		  @else{}
@@ -62,9 +62,9 @@
 		@else{method.returnType.kind == CLASS_SET}
 			@code{cachedType=method.returnType.name}
 			@if{method.returnType.args[0].kind == CLASS_JSON_OBJECT}
-		    def ret = @includeNamed{'invokeDelegate';method=method}?.collect({underpants -> underpants.getMap()}) as Set;\n
+		    def ret = @includeNamed{'invokeDelegate';method=method}?.collect({underpants -> InternalHelper.wrapObject(underpants)}) as Set;\n
 			@else{method.returnType.args[0].kind == CLASS_JSON_ARRAY}
-		    def ret = @includeNamed{'invokeDelegate';method=method}?.collect({underpants -> underpants.getList()}) as Set;\n
+		    def ret = @includeNamed{'invokeDelegate';method=method}?.collect({underpants -> InternalHelper.wrapObject(underpants)}) as Set;\n
 			@else{method.returnType.args[0].kind == CLASS_API}
 		    def ret = @includeNamed{'invokeDelegate';method=method}?.collect({underpants -> @{genConstructor(method.returnType.args[0], "underpants")}}) as Set;\n
 			@else{}
@@ -73,9 +73,9 @@
 		@else{method.returnType.kind == CLASS_MAP}
 			@code{cachedType=method.returnType.name}
 			@if{method.returnType.args[1].kind == CLASS_JSON_OBJECT}
-		    def ret = @includeNamed{'invokeDelegate';method=method}?.collectEntries({k, v -> [k, v.getMap()]});\n
+		    def ret = @includeNamed{'invokeDelegate';method=method}?.collectEntries({k, v -> [k, InternalHelper.wrapObject(v)]});\n
 			@else{method.returnType.args[1].kind == CLASS_JSON_ARRAY}
-		    def ret = @includeNamed{'invokeDelegate';method=method}?.collectEntries({k, v -> [k, v.getList()]});\n
+		    def ret = @includeNamed{'invokeDelegate';method=method}?.collectEntries({k, v -> [k, InternalHelper.wrapObject(v)]});\n
 			@else{method.returnType.args[1].kind == CLASS_API}
 		    def ret = @includeNamed{'invokeDelegate';method=method}?.collectEntries({k, v -> [k, @{genConstructor(method.returnType.args[0], "v")}]});\n
 			@else{}

--- a/src/main/resources/vertx-groovy/template/groovy.templ
+++ b/src/main/resources/vertx-groovy/template/groovy.templ
@@ -170,19 +170,19 @@ this.delegate
 		@else{eventKind == CLASS_DATA_OBJECT}
 			new Handler<@{eventType.simpleName}>() {\n
 			      public void handle(@{eventType.simpleName} event) {\n
-			        @{param.name}.handle(event?.toJson()?.getMap());\n
+			        @{param.name}.handle((Map<String, Object>)InternalHelper.wrapObject(event?.toJson()));\n
 			      }\n
 			    }
 		@else{eventKind == CLASS_JSON_OBJECT}
 			new Handler<JsonObject>() {\n
 			      public void handle(JsonObject event) {\n
-			        @{param.name}.handle(event?.getMap());\n
+			        @{param.name}.handle((Map<String, Object>)InternalHelper.wrapObject(event));\n
 			      }\n
 			    }
 		@else{eventKind == CLASS_JSON_ARRAY}
 			new Handler<JsonArray>() {\n
 			      public void handle(JsonArray event) {\n
-			        @{param.name}.handle(event?.toList());\n
+			        @{param.name}.handle((List<Object>)InternalHelper.wrapObject(event));\n
 			      }\n
 			    }
 		@else{eventKind == CLASS_LIST || eventKind == CLASS_SET}
@@ -196,13 +196,13 @@ this.delegate
 					@code{toGroovyElement='' + genConstructor(elementType, "it")}
 					@code{elementJavaType=elementType.name}
 				@else{elementKind == CLASS_JSON_OBJECT}
-					@code{toGroovyElement='it?.getMap()'}
+					@code{toGroovyElement='InternalHelper.wrapObject(it)'}
 					@code{elementJavaType='JsonObject'}
 				@else{elementKind == CLASS_DATA_OBJECT}
-					@code{toGroovyElement='it?.toJson()?.getMap()'}
+					@code{toGroovyElement='(Map<String, Object>)InternalHelper.wrapObject(it?.toJson())'}
 					@code{elementJavaType=elementType.simpleName}
 				@else{}
-					@code{toGroovyElement='it?.toList()'}
+					@code{toGroovyElement='InternalHelper.wrapObject(it)'}
 					@code{elementJavaType='JsonArray'}
 				@end{}
 				new Handler<@{collectionName}<@{elementJavaType}>>() {\n
@@ -227,7 +227,7 @@ this.delegate
 			@if{resultKind == CLASS_OTHER || resultKind.basic || resultKind == CLASS_VOID}
 				@{param.name}
 			@else{resultKind == CLASS_DATA_OBJECT}
-				@includeNamed{'resultHandlerTemplate';eventJavaType=resultType.name;eventGroovyType='Map<String, Object>';callbackObject='event.result()?.toJson()?.getMap()';callbackName=param.name}
+				@includeNamed{'resultHandlerTemplate';eventJavaType=resultType.name;eventGroovyType='Map<String, Object>';callbackObject='(Map<String, Object>)InternalHelper.wrapObject(event.result()?.toJson())';callbackName=param.name}
 			@else{resultKind == CLASS_LIST || resultKind == CLASS_SET}
 				@code{elementType=resultType.args[0]}
 				@code{elementKind=elementType.kind}
@@ -240,15 +240,15 @@ this.delegate
 						@code{elementJavaType=elementType.name}
 						@code{elementGroovyType=elementType.simpleName}
 					@else{elementKind == CLASS_DATA_OBJECT}
-						@code{toGroovyElement='element?.toJson()?.getMap()'}
+						@code{toGroovyElement='(Map<String, Object>)InternalHelper.wrapObject(element?.toJson())'}
 						@code{elementJavaType=elementType.simpleName}
 						@code{elementGroovyType='Map<String, Object>'}
 					@else{elementKind == CLASS_JSON_OBJECT}
-						@code{toGroovyElement='element?.getMap()'}
+						@code{toGroovyElement='InternalHelper.wrapObject(element)'}
 						@code{elementJavaType='JsonObject'}
 						@code{elementGroovyType='Map<String, Object>'}
 					@else{}
-						@code{toGroovyElement='element?.toList()'}
+						@code{toGroovyElement='InternalHelper.wrapObject(element)'}
 						@code{elementJavaType='JsonArray'}
 						@code{elementGroovyType='List<Object>'}
 					@end{}
@@ -260,9 +260,9 @@ this.delegate
 					null
 				@end{}
 			@else{resultKind == CLASS_JSON_OBJECT}
-				@includeNamed{'resultHandlerTemplate';eventJavaType=resultType.name;eventGroovyType='Map<String, Object>';callbackObject='event.result()?.getMap()';callbackName=param.name}
+				@includeNamed{'resultHandlerTemplate';eventJavaType=resultType.name;eventGroovyType='Map<String, Object>';callbackObject='(' + eventGroovyType + ')InternalHelper.wrapObject(event.result())';callbackName=param.name}
 			@else{resultKind == CLASS_JSON_ARRAY}
-				@includeNamed{'resultHandlerTemplate';eventJavaType=resultType.name;eventGroovyType='List<Object>';callbackObject='event.result()?.toList()';callbackName=param.name}
+				@includeNamed{'resultHandlerTemplate';eventJavaType=resultType.name;eventGroovyType='List<Object>';callbackObject='(' + eventGroovyType + ')InternalHelper.wrapObject(event.result())';callbackName=param.name}
 			@else{resultKind == CLASS_OBJECT}
 				@includeNamed{'resultHandlerTemplate';eventJavaType='Object';eventGroovyType='Object';callbackObject='InternalHelper.wrapObject(event.result())';callbackName=param.name}
 			@else{resultKind == CLASS_API}

--- a/src/test/groovy/io/vertx/lang/groovy/ApiTest.groovy
+++ b/src/test/groovy/io/vertx/lang/groovy/ApiTest.groovy
@@ -293,6 +293,17 @@ public class ApiTest {
       assertEquals([null], it);
       count++;
     });
+    assertEquals(1, count) 
+  }
+  
+  @Test
+  public void testMethodWithHandlerListComplexJsonObject() {
+    def count = 0;
+
+    obj.methodWithHandlerListComplexJsonObject({
+      assertEquals([[outer: [socks: "tartan"], list: ["yellow", "blue"]]], it);
+      count++;
+    });
     assertEquals(1, count)
   }
 
@@ -310,6 +321,15 @@ public class ApiTest {
     def checker = new AsyncResultChecker();
     obj.methodWithHandlerAsyncResultListNullJsonObject({
       checker.assertAsyncResult([null], it)
+    })
+    assertEquals(1, checker.count);
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultListComplexJsonObject() {
+    def checker = new AsyncResultChecker();
+    obj.methodWithHandlerAsyncResultListComplexJsonObject({
+      checker.assertAsyncResult([[outer: [socks: "tartan"], list: ["yellow", "blue"]]], it)
     })
     assertEquals(1, checker.count);
   }
@@ -335,6 +355,16 @@ public class ApiTest {
   }
 
   @Test
+  public void testMethodWithHandlerSetComplexJsonObject() {
+    def count = 0;
+    obj.methodWithHandlerSetComplexJsonObject({
+      assertEquals([[outer: [socks: "tartan"], list: ["yellow", "blue"]]] as Set, it);
+      count++;
+    });
+    assertEquals(1, count)
+  }
+
+  @Test
   public void testMethodWithHandlerAsyncResultSetJsonObject() {
     def checker = new AsyncResultChecker();
     obj.methodWithHandlerAsyncResultSetJsonObject({
@@ -348,6 +378,15 @@ public class ApiTest {
     def checker = new AsyncResultChecker();
     obj.methodWithHandlerAsyncResultSetNullJsonObject({
       checker.assertAsyncResult([null] as Set, it)
+    })
+    assertEquals(1, checker.count);
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultSetComplexJsonObject() {
+    def checker = new AsyncResultChecker();
+    obj.methodWithHandlerAsyncResultSetComplexJsonObject({
+      checker.assertAsyncResult([[outer: [socks: "tartan"], list: ["yellow", "blue"]]] as Set, it)
     })
     assertEquals(1, checker.count);
   }
@@ -367,6 +406,16 @@ public class ApiTest {
     def count = 0;
     obj.methodWithHandlerListNullJsonArray({
       assertEquals([null], it);
+      count++;
+    });
+    assertEquals(1, count)
+  }
+
+  @Test
+  public void testMethodWithHandlerListComplexJsonArray() {
+    def count = 0;
+    obj.methodWithHandlerListComplexJsonArray({
+      assertEquals([[[foo: "hello"]], [[bar: "bye"]]], it);
       count++;
     });
     assertEquals(1, count)
@@ -436,6 +485,15 @@ public class ApiTest {
   }
 
   @Test
+  public void testMethodWithHandlerAsyncResultListComplexJsonArray() {
+    def checker = new AsyncResultChecker();
+    obj.methodWithHandlerAsyncResultListComplexJsonArray({
+      checker.assertAsyncResult([[[foo: "hello"]], [[bar: "bye"]]], it)
+    });
+    assertEquals(1, checker.count);
+  }
+
+  @Test
   public void testMethodWithHandlerSetJsonArray() {
     def count = 0;
     obj.methodWithHandlerSetJsonArray({
@@ -456,6 +514,16 @@ public class ApiTest {
   }
 
   @Test
+  public void testMethodWithHandlerSetComplexJsonArray() {
+    def count = 0;
+    obj.methodWithHandlerSetComplexJsonArray({
+      assertEquals([[[foo: "hello"]], [[bar: "bye"]]] as Set, it);
+      count++;
+    });
+    assertEquals(1, count)
+  }
+
+  @Test
   public void testMethodWithHandlerAsyncResultSetJsonArray() {
     def checker = new AsyncResultChecker();
     obj.methodWithHandlerAsyncResultSetJsonArray({
@@ -469,6 +537,15 @@ public class ApiTest {
     def checker = new AsyncResultChecker();
     obj.methodWithHandlerAsyncResultSetNullJsonArray({
       checker.assertAsyncResult([null] as Set, it)
+    });
+    assertEquals(1, checker.count);
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultSetComplexJsonArray() {
+    def checker = new AsyncResultChecker();
+    obj.methodWithHandlerAsyncResultSetComplexJsonArray({
+      checker.assertAsyncResult([[[foo: "hello"]], [[bar: "bye"]]] as Set, it)
     });
     assertEquals(1, checker.count);
   }
@@ -664,6 +741,11 @@ public class ApiTest {
       assertEquals(["foo", "bar", "wib"], it)
       count++
     })
+    count = 0;
+    obj.methodWithGenericHandler("JsonObjectComplex", {
+      assertEquals([outer: [foo: "hello"], bar: ["this", "that"]], it)
+      count++
+    })
     assertEquals(1, count);
   }
 
@@ -683,6 +765,11 @@ public class ApiTest {
     checker = new AsyncResultChecker();
     obj.methodWithGenericHandlerAsyncResult("JsonObject", {
       checker.assertAsyncResult([foo:"hello","bar":123], it)
+    })
+    assertEquals(1, checker.count);
+    checker = new AsyncResultChecker();
+    obj.methodWithGenericHandlerAsyncResult("JsonObjectComplex", {
+      checker.assertAsyncResult([outer: [foo: "hello"], bar: ["this", "that"]], it)
     })
     assertEquals(1, checker.count);
     checker = new AsyncResultChecker();
@@ -784,6 +871,14 @@ public class ApiTest {
   }
 
   @Test
+  public void testListComplexJsonObjectReturn() {
+    List<Map<String, Object>> list = obj.methodWithListComplexJsonObjectReturn();
+    assertEquals(1, list.size());
+    Map<String, Object> json1 = list.get(0);
+    assertEquals([outer: [socks: "tartan"], list: ["yellow", "blue"]], json1);
+  }
+
+  @Test
   public void testListJsonArrayReturn() {
     List<List<Object>> list = obj.methodWithListJsonArrayReturn();
     assertEquals(2, list.size());
@@ -791,6 +886,16 @@ public class ApiTest {
     assertEquals("foo", json1.get(0));
     List<Object> json2 = list.get(1);
     assertEquals("blah", json2.get(0));
+  }
+
+  @Test
+  public void testListComplexJsonArrayReturn() {
+    List<List<Object>> list = obj.methodWithListComplexJsonArrayReturn();
+    assertEquals(2, list.size());
+    List<Object> json1 = list.get(0);
+    assertEquals([[foo: "hello"]], json1);
+    List<Object> json2 = list.get(1);
+    assertEquals([[bar: "bye"]], json2);
   }
 
   @Test
@@ -827,6 +932,13 @@ public class ApiTest {
   }
 
   @Test
+  public void testSetComplexJsonObjectReturn() {
+    Set<Map<String, Object>> set = obj.methodWithSetComplexJsonObjectReturn();
+    assertEquals(1, set.size());
+    assertTrue(set.contains([outer: [socks: "tartan"], list: ["yellow", "blue"]]));
+  }
+
+  @Test
   public void testSetJsonArrayReturn() {
     Set<List<Object>> set = obj.methodWithSetJsonArrayReturn();
     assertEquals(2, set.size());
@@ -836,6 +948,14 @@ public class ApiTest {
     List<Object> json2 = new ArrayList<>();
     json2.add("blah");
     assertTrue(set.contains(json2));
+  }
+
+  @Test
+  public void testSetComplexJsonArrayReturn() {
+    Set<List<Object>> set = obj.methodWithSetComplexJsonArrayReturn();
+    assertEquals(2, set.size());
+    assertTrue(set.contains([[foo: "hello"]]));
+    assertTrue(set.contains([[bar: "bye"]]));
   }
 
   @Test
@@ -870,10 +990,24 @@ public class ApiTest {
   }
 
   @Test
+  public void testMapComplexJsonObjectReturn() {
+    Map<String, Map<String, Object>> map = obj.methodWithMapComplexJsonObjectReturn({});
+    Map<String, Object> m = map.get("foo");
+    assertEquals([outer: [socks: "tartan"], list: ["yellow", "blue"]], m);
+  }
+
+  @Test
   public void testMapJsonArrayReturn() {
     Map<String, List<Object>> map = obj.methodWithMapJsonArrayReturn({});
     List<Object> m = map.get("foo");
     assertEquals("wibble", m.get(0));
+  }
+
+  @Test
+  public void testMapComplexJsonArrayReturn() {
+    Map<String, List<Object>> map = obj.methodWithMapComplexJsonArrayReturn({});
+    List<Object> m = map.get("foo");
+    assertEquals([[foo: "hello"], [bar: "bye"]], m);
   }
 
   @Test
@@ -947,6 +1081,14 @@ public class ApiTest {
   }
 
   @Test
+  public void testComplexJsonReturns() {
+    def ret = obj.methodWithComplexJsonObjectReturn();
+    assertEquals([outer: [socks: "tartan"], list: ["yellow", "blue"]], ret);
+    ret = obj.methodWithComplexJsonArrayReturn();
+    assertEquals([[foo: "hello"], [bar: "bye"]], ret);
+  }
+
+  @Test
   public void testJsonParams() {
     obj.methodWithJsonParams([cat:"lion",cheese:"cheddar"], ["house","spider"]);
   }
@@ -982,6 +1124,20 @@ public class ApiTest {
     assertEquals(2, count);
   }
 
+
+  @Test
+  public void testComplexJsonHandlerParams() {
+    def count = 0;
+    obj.methodWithHandlerComplexJson({
+      assertEquals([outer: [socks: "tartan"], list: ["yellow", "blue"]], it)
+      count++;
+    }, {
+      assertEquals([[[foo: "hello"]], [[bar: "bye"]]], it)
+      count++;
+    });
+    assertEquals(2, count);
+  }
+
   @Test
   public void testJsonHandlerAsyncResultParams() {
     def checker = new AsyncResultChecker();
@@ -1002,6 +1158,18 @@ public class ApiTest {
     });
     obj.methodWithHandlerAsyncResultNullJsonArray({
       checker.assertAsyncResult(null, it)
+    });
+    assertEquals(2, checker.count);
+  }
+
+  @Test
+  public void testComplexJsonHandlerAsyncResultParams() {
+    def checker = new AsyncResultChecker();
+    obj.methodWithHandlerAsyncResultComplexJsonObject({
+      checker.assertAsyncResult([outer: [socks: "tartan"], list: ["yellow", "blue"]], it)
+    });
+    obj.methodWithHandlerAsyncResultComplexJsonArray({
+      checker.assertAsyncResult([[foo: "hello"], [bar: "bye"]], it)
     });
     assertEquals(2, checker.count);
   }

--- a/src/test/groovy/io/vertx/lang/groovy/EventBusTest.groovy
+++ b/src/test/groovy/io/vertx/lang/groovy/EventBusTest.groovy
@@ -66,4 +66,20 @@ class EventBusTest extends VertxTestBase {
     eventBus.send("the_address", "${val}")
     await()
   }
+
+  @Test
+  public void testComplexJson() {
+    def val = [outer: [inner: 'value'], list: ['v1', 'v2', 'v3']]
+    def eventBus = _vertx.eventBus()
+    eventBus.consumer("the_address").handler { message ->
+      def body = message.body()
+      if (body instanceof Map && body.equals(val)) {
+        testComplete()
+      } else {
+        fail()
+      }
+    }
+    eventBus.send("the_address", val)
+    await()
+  }
 }


### PR DESCRIPTION
We want to ensure that nested JsonObject and JsonArray instances are properly converted.  This is done by InternalHelper.wrapObject() so we want to use this method instead of directly extracting the map and/or list.

To help test this we added new methods to the codegen model and used those to add new test cases here in ApiTest.  This relies on https://github.com/vert-x3/vertx-codegen/pull/33.

Added a new test to EventBusTest to test sending and receiving nested Json objects.

Signed-off-by: Sean Fitts <smfitts@gmail.com>