### PR TITLE
#13 broken groovydoc links

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -955,20 +955,27 @@ vertx -ha
 
 Depending on your cluster configuration, you may have to append the `cluster-host` and `cluster-port` parameters.
 
-=== Executing verticles packaged as a fat jar
+=== Executing a Vert.x application packaged as a fat jar
 
 A _fat jar_ is an executable jar embedding its dependencies. This means you don't have to have Vert.x pre-installed
-on the machine on which you execute the jar. A verticle packaged as a _fat jar_ can just be launched using:
+on the machine on which you execute the jar. Like any executable Java jar it can be executed with.
 
 [source]
 ----
-java -jar my-verticle-fat.jar
+java -jar my-application-fat.jar
 ----
 
-The _fat jar_ must have a _manifest_ with:
+There is nothing really Vert.x specific about this, you could do this with any Java application
+
+You can either create your own main class and specify that in the manifest, but it's recommended that you write your
+code as verticles and use the Vert.x `Starter` class as your main class. This is the same main class used when running
+Vert.x at the command line and therefore allows you to specify command line arguments, such as `-instances` in order
+to scale your application more easily.
+
+To deploy your verticle in a _fatjar_ like this you must have a _manifest_ with:
 
 * `Main-Class` set to `io.vertx.core.Starter`
-* `Main-Verticle` specifying the main verticle (fully qualified name)
+* `Main-Verticle` specifying the main verticle (fully qualified class name or script file name)
 
 You can also provide the usual command line arguments that you would pass to `vertx run`:
 [source]
@@ -977,7 +984,8 @@ java -jar my-verticle-fat.jar -cluster -conf myconf.json
 java -jar my-verticle-fat.jar -cluster -conf myconf.json -cp path/to/dir/conf/cluster_xml
 ----
 
-NOTE: _fat jar_ can be built using Gradle build or the Maven plugin. Check the vertx examples for instructions.
+NOTE: Please consult the Maven/Gradle simplest and Maven/Gradle verticle examples in the examples repository for
+examples of building applications as fatjars.
 
 === Displaying version of Vert.x
 To display the vert.x version, just launch:

--- a/src/main/groovy/io/vertx/groovy/core/Context.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/Context.groovy
@@ -54,9 +54,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class Context {
-  final def io.vertx.core.Context delegate;
-  public Context(io.vertx.core.Context delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.Context delegate;
+  public Context(Object delegate) {
+    this.delegate = (io.vertx.core.Context) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -189,7 +189,7 @@ public class Context {
    * @return 
    */
   public Vertx owner() {
-    def ret= InternalHelper.safeCreate(this.delegate.owner(), io.vertx.core.Vertx.class, io.vertx.groovy.core.Vertx.class);
+    def ret= InternalHelper.safeCreate(this.delegate.owner(), io.vertx.groovy.core.Vertx.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/Future.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/Future.groovy
@@ -25,9 +25,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class Future<T> {
-  final def io.vertx.core.Future delegate;
-  public Future(io.vertx.core.Future delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.Future delegate;
+  public Future(Object delegate) {
+    this.delegate = (io.vertx.core.Future) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -37,7 +37,7 @@ public class Future<T> {
    * @return the future
    */
   public static <T> Future<T> future() {
-    def ret= InternalHelper.safeCreate(io.vertx.core.Future.future(), io.vertx.core.Future.class, io.vertx.groovy.core.Future.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.Future.future(), io.vertx.groovy.core.Future.class);
     return ret;
   }
   /**
@@ -45,7 +45,7 @@ public class Future<T> {
    * @return the future
    */
   public static <T> Future<T> succeededFuture() {
-    def ret= InternalHelper.safeCreate(io.vertx.core.Future.succeededFuture(), io.vertx.core.Future.class, io.vertx.groovy.core.Future.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.Future.succeededFuture(), io.vertx.groovy.core.Future.class);
     return ret;
   }
   /**
@@ -54,7 +54,7 @@ public class Future<T> {
    * @return the future
    */
   public static <T> Future<T> succeededFuture(T result) {
-    def ret= InternalHelper.safeCreate(io.vertx.core.Future.succeededFuture(InternalHelper.unwrapObject(result)), io.vertx.core.Future.class, io.vertx.groovy.core.Future.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.Future.succeededFuture(InternalHelper.unwrapObject(result)), io.vertx.groovy.core.Future.class);
     return ret;
   }
   /**
@@ -63,7 +63,7 @@ public class Future<T> {
    * @return the future
    */
   public static <T> Future<T> failedFuture(String failureMessage) {
-    def ret= InternalHelper.safeCreate(io.vertx.core.Future.failedFuture(failureMessage), io.vertx.core.Future.class, io.vertx.groovy.core.Future.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.Future.failedFuture(failureMessage), io.vertx.groovy.core.Future.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/MultiMap.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/MultiMap.groovy
@@ -28,9 +28,9 @@ import java.util.Set
 */
 @CompileStatic
 public class MultiMap {
-  final def io.vertx.core.MultiMap delegate;
-  public MultiMap(io.vertx.core.MultiMap delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.MultiMap delegate;
+  public MultiMap(Object delegate) {
+    this.delegate = (io.vertx.core.MultiMap) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -40,7 +40,7 @@ public class MultiMap {
    * @return the multi-map
    */
   public static MultiMap caseInsensitiveMultiMap() {
-    def ret= InternalHelper.safeCreate(io.vertx.core.MultiMap.caseInsensitiveMultiMap(), io.vertx.core.MultiMap.class, io.vertx.groovy.core.MultiMap.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.MultiMap.caseInsensitiveMultiMap(), io.vertx.groovy.core.MultiMap.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/TimeoutStream.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/TimeoutStream.groovy
@@ -29,31 +29,31 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class TimeoutStream implements ReadStream<Long> {
-  final def io.vertx.core.TimeoutStream delegate;
-  public TimeoutStream(io.vertx.core.TimeoutStream delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.TimeoutStream delegate;
+  public TimeoutStream(Object delegate) {
+    this.delegate = (io.vertx.core.TimeoutStream) delegate;
   }
   public Object getDelegate() {
     return delegate;
   }
   public TimeoutStream exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.TimeoutStream) this.delegate).exceptionHandler(handler);
     return this;
   }
   public TimeoutStream handler(Handler<Long> handler) {
-    this.delegate.handler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.TimeoutStream) this.delegate).handler(handler);
     return this;
   }
   public TimeoutStream pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.TimeoutStream) this.delegate).pause();
     return this;
   }
   public TimeoutStream resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.TimeoutStream) this.delegate).resume();
     return this;
   }
   public TimeoutStream endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.TimeoutStream) this.delegate).endHandler(endHandler);
     return this;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/Vertx.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/Vertx.groovy
@@ -62,9 +62,9 @@ import io.vertx.groovy.core.http.HttpClient
 */
 @CompileStatic
 public class Vertx implements Measured {
-  final def io.vertx.core.Vertx delegate;
-  public Vertx(io.vertx.core.Vertx delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.Vertx delegate;
+  public Vertx(Object delegate) {
+    this.delegate = (io.vertx.core.Vertx) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -82,7 +82,7 @@ public class Vertx implements Measured {
    * @return the instance
    */
   public static Vertx vertx() {
-    def ret= InternalHelper.safeCreate(io.vertx.core.Vertx.vertx(), io.vertx.core.Vertx.class, io.vertx.groovy.core.Vertx.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.Vertx.vertx(), io.vertx.groovy.core.Vertx.class);
     return ret;
   }
   /**
@@ -91,7 +91,7 @@ public class Vertx implements Measured {
    * @return the instance
    */
   public static Vertx vertx(Map<String, Object> options) {
-    def ret= InternalHelper.safeCreate(io.vertx.core.Vertx.vertx(options != null ? new io.vertx.core.VertxOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.core.Vertx.class, io.vertx.groovy.core.Vertx.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.Vertx.vertx(options != null ? new io.vertx.core.VertxOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.groovy.core.Vertx.class);
     return ret;
   }
   /**
@@ -119,7 +119,7 @@ public class Vertx implements Measured {
    * @return The current context or null if no current context
    */
   public static Context currentContext() {
-    def ret= InternalHelper.safeCreate(io.vertx.core.Vertx.currentContext(), io.vertx.core.Context.class, io.vertx.groovy.core.Context.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.Vertx.currentContext(), io.vertx.groovy.core.Context.class);
     return ret;
   }
   /**
@@ -127,7 +127,7 @@ public class Vertx implements Measured {
    * @return The current context (created if didn't exist)
    */
   public Context getOrCreateContext() {
-    def ret= InternalHelper.safeCreate(this.delegate.getOrCreateContext(), io.vertx.core.Context.class, io.vertx.groovy.core.Context.class);
+    def ret= InternalHelper.safeCreate(this.delegate.getOrCreateContext(), io.vertx.groovy.core.Context.class);
     return ret;
   }
   /**
@@ -136,7 +136,7 @@ public class Vertx implements Measured {
    * @return the server
    */
   public NetServer createNetServer(Map<String, Object> options) {
-    def ret= InternalHelper.safeCreate(this.delegate.createNetServer(options != null ? new io.vertx.core.net.NetServerOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.core.net.NetServer.class, io.vertx.groovy.core.net.NetServer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.createNetServer(options != null ? new io.vertx.core.net.NetServerOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.groovy.core.net.NetServer.class);
     return ret;
   }
   /**
@@ -144,7 +144,7 @@ public class Vertx implements Measured {
    * @return the server
    */
   public NetServer createNetServer() {
-    def ret= InternalHelper.safeCreate(this.delegate.createNetServer(), io.vertx.core.net.NetServer.class, io.vertx.groovy.core.net.NetServer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.createNetServer(), io.vertx.groovy.core.net.NetServer.class);
     return ret;
   }
   /**
@@ -153,7 +153,7 @@ public class Vertx implements Measured {
    * @return the client
    */
   public NetClient createNetClient(Map<String, Object> options) {
-    def ret= InternalHelper.safeCreate(this.delegate.createNetClient(options != null ? new io.vertx.core.net.NetClientOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.core.net.NetClient.class, io.vertx.groovy.core.net.NetClient.class);
+    def ret= InternalHelper.safeCreate(this.delegate.createNetClient(options != null ? new io.vertx.core.net.NetClientOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.groovy.core.net.NetClient.class);
     return ret;
   }
   /**
@@ -161,7 +161,7 @@ public class Vertx implements Measured {
    * @return the client
    */
   public NetClient createNetClient() {
-    def ret= InternalHelper.safeCreate(this.delegate.createNetClient(), io.vertx.core.net.NetClient.class, io.vertx.groovy.core.net.NetClient.class);
+    def ret= InternalHelper.safeCreate(this.delegate.createNetClient(), io.vertx.groovy.core.net.NetClient.class);
     return ret;
   }
   /**
@@ -170,7 +170,7 @@ public class Vertx implements Measured {
    * @return the server
    */
   public HttpServer createHttpServer(Map<String, Object> options) {
-    def ret= InternalHelper.safeCreate(this.delegate.createHttpServer(options != null ? new io.vertx.core.http.HttpServerOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.core.http.HttpServer.class, io.vertx.groovy.core.http.HttpServer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.createHttpServer(options != null ? new io.vertx.core.http.HttpServerOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.groovy.core.http.HttpServer.class);
     return ret;
   }
   /**
@@ -178,7 +178,7 @@ public class Vertx implements Measured {
    * @return the server
    */
   public HttpServer createHttpServer() {
-    def ret= InternalHelper.safeCreate(this.delegate.createHttpServer(), io.vertx.core.http.HttpServer.class, io.vertx.groovy.core.http.HttpServer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.createHttpServer(), io.vertx.groovy.core.http.HttpServer.class);
     return ret;
   }
   /**
@@ -187,7 +187,7 @@ public class Vertx implements Measured {
    * @return the client
    */
   public HttpClient createHttpClient(Map<String, Object> options) {
-    def ret= InternalHelper.safeCreate(this.delegate.createHttpClient(options != null ? new io.vertx.core.http.HttpClientOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    def ret= InternalHelper.safeCreate(this.delegate.createHttpClient(options != null ? new io.vertx.core.http.HttpClientOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -195,7 +195,7 @@ public class Vertx implements Measured {
    * @return the client
    */
   public HttpClient createHttpClient() {
-    def ret= InternalHelper.safeCreate(this.delegate.createHttpClient(), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    def ret= InternalHelper.safeCreate(this.delegate.createHttpClient(), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -204,7 +204,7 @@ public class Vertx implements Measured {
    * @return the socket
    */
   public DatagramSocket createDatagramSocket(Map<String, Object> options) {
-    def ret= InternalHelper.safeCreate(this.delegate.createDatagramSocket(options != null ? new io.vertx.core.datagram.DatagramSocketOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.core.datagram.DatagramSocket.class, io.vertx.groovy.core.datagram.DatagramSocket.class);
+    def ret= InternalHelper.safeCreate(this.delegate.createDatagramSocket(options != null ? new io.vertx.core.datagram.DatagramSocketOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.groovy.core.datagram.DatagramSocket.class);
     return ret;
   }
   /**
@@ -212,7 +212,7 @@ public class Vertx implements Measured {
    * @return the socket
    */
   public DatagramSocket createDatagramSocket() {
-    def ret= InternalHelper.safeCreate(this.delegate.createDatagramSocket(), io.vertx.core.datagram.DatagramSocket.class, io.vertx.groovy.core.datagram.DatagramSocket.class);
+    def ret= InternalHelper.safeCreate(this.delegate.createDatagramSocket(), io.vertx.groovy.core.datagram.DatagramSocket.class);
     return ret;
   }
   /**
@@ -223,7 +223,7 @@ public class Vertx implements Measured {
     if (cached_0 != null) {
       return cached_0;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.fileSystem(), io.vertx.core.file.FileSystem.class, io.vertx.groovy.core.file.FileSystem.class);
+    def ret= InternalHelper.safeCreate(this.delegate.fileSystem(), io.vertx.groovy.core.file.FileSystem.class);
     cached_0 = ret;
     return ret;
   }
@@ -235,7 +235,7 @@ public class Vertx implements Measured {
     if (cached_1 != null) {
       return cached_1;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.eventBus(), io.vertx.core.eventbus.EventBus.class, io.vertx.groovy.core.eventbus.EventBus.class);
+    def ret= InternalHelper.safeCreate(this.delegate.eventBus(), io.vertx.groovy.core.eventbus.EventBus.class);
     cached_1 = ret;
     return ret;
   }
@@ -246,7 +246,7 @@ public class Vertx implements Measured {
    * @return the DNS client
    */
   public DnsClient createDnsClient(int port, String host) {
-    def ret= InternalHelper.safeCreate(this.delegate.createDnsClient(port, host), io.vertx.core.dns.DnsClient.class, io.vertx.groovy.core.dns.DnsClient.class);
+    def ret= InternalHelper.safeCreate(this.delegate.createDnsClient(port, host), io.vertx.groovy.core.dns.DnsClient.class);
     return ret;
   }
   /**
@@ -257,7 +257,7 @@ public class Vertx implements Measured {
     if (cached_2 != null) {
       return cached_2;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.sharedData(), io.vertx.core.shareddata.SharedData.class, io.vertx.groovy.core.shareddata.SharedData.class);
+    def ret= InternalHelper.safeCreate(this.delegate.sharedData(), io.vertx.groovy.core.shareddata.SharedData.class);
     cached_2 = ret;
     return ret;
   }
@@ -279,7 +279,7 @@ public class Vertx implements Measured {
    * @return the timer stream
    */
   public TimeoutStream timerStream(long delay) {
-    def ret= InternalHelper.safeCreate(this.delegate.timerStream(delay), io.vertx.core.TimeoutStream.class, io.vertx.groovy.core.TimeoutStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.timerStream(delay), io.vertx.groovy.core.TimeoutStream.class);
     return ret;
   }
   /**
@@ -300,7 +300,7 @@ public class Vertx implements Measured {
    * @return the periodic stream
    */
   public TimeoutStream periodicStream(long delay) {
-    def ret= InternalHelper.safeCreate(this.delegate.periodicStream(delay), io.vertx.core.TimeoutStream.class, io.vertx.groovy.core.TimeoutStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.periodicStream(delay), io.vertx.groovy.core.TimeoutStream.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/buffer/Buffer.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/buffer/Buffer.groovy
@@ -28,9 +28,9 @@ import io.vertx.core.shareddata.impl.ClusterSerializable
 */
 @CompileStatic
 public class Buffer {
-  final def io.vertx.core.buffer.Buffer delegate;
-  public Buffer(io.vertx.core.buffer.Buffer delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.buffer.Buffer delegate;
+  public Buffer(Object delegate) {
+    this.delegate = (io.vertx.core.buffer.Buffer) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -40,7 +40,7 @@ public class Buffer {
    * @return the buffer
    */
   public static Buffer buffer() {
-    def ret= InternalHelper.safeCreate(io.vertx.core.buffer.Buffer.buffer(), io.vertx.core.buffer.Buffer.class, io.vertx.groovy.core.buffer.Buffer.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.buffer.Buffer.buffer(), io.vertx.groovy.core.buffer.Buffer.class);
     return ret;
   }
   /**
@@ -52,7 +52,7 @@ public class Buffer {
    * @return the buffer
    */
   public static Buffer buffer(int initialSizeHint) {
-    def ret= InternalHelper.safeCreate(io.vertx.core.buffer.Buffer.buffer(initialSizeHint), io.vertx.core.buffer.Buffer.class, io.vertx.groovy.core.buffer.Buffer.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.buffer.Buffer.buffer(initialSizeHint), io.vertx.groovy.core.buffer.Buffer.class);
     return ret;
   }
   /**
@@ -61,7 +61,7 @@ public class Buffer {
    * @return the buffer
    */
   public static Buffer buffer(String string) {
-    def ret= InternalHelper.safeCreate(io.vertx.core.buffer.Buffer.buffer(string), io.vertx.core.buffer.Buffer.class, io.vertx.groovy.core.buffer.Buffer.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.buffer.Buffer.buffer(string), io.vertx.groovy.core.buffer.Buffer.class);
     return ret;
   }
   /**
@@ -72,7 +72,7 @@ public class Buffer {
    * @return the buffer
    */
   public static Buffer buffer(String string, String enc) {
-    def ret= InternalHelper.safeCreate(io.vertx.core.buffer.Buffer.buffer(string, enc), io.vertx.core.buffer.Buffer.class, io.vertx.groovy.core.buffer.Buffer.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.buffer.Buffer.buffer(string, enc), io.vertx.groovy.core.buffer.Buffer.class);
     return ret;
   }
   /**
@@ -146,7 +146,7 @@ public class Buffer {
    * @return 
    */
   public Buffer getBuffer(int start, int end) {
-    def ret= InternalHelper.safeCreate(this.delegate.getBuffer(start, end), io.vertx.core.buffer.Buffer.class, io.vertx.groovy.core.buffer.Buffer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.getBuffer(start, end), io.vertx.groovy.core.buffer.Buffer.class);
     return ret;
   }
   /**
@@ -406,7 +406,7 @@ public class Buffer {
    * @return 
    */
   public Buffer copy() {
-    def ret= InternalHelper.safeCreate(this.delegate.copy(), io.vertx.core.buffer.Buffer.class, io.vertx.groovy.core.buffer.Buffer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.copy(), io.vertx.groovy.core.buffer.Buffer.class);
     return ret;
   }
   /**
@@ -416,7 +416,7 @@ public class Buffer {
    * @return 
    */
   public Buffer slice() {
-    def ret= InternalHelper.safeCreate(this.delegate.slice(), io.vertx.core.buffer.Buffer.class, io.vertx.groovy.core.buffer.Buffer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.slice(), io.vertx.groovy.core.buffer.Buffer.class);
     return ret;
   }
   /**
@@ -428,7 +428,7 @@ public class Buffer {
    * @return 
    */
   public Buffer slice(int start, int end) {
-    def ret= InternalHelper.safeCreate(this.delegate.slice(start, end), io.vertx.core.buffer.Buffer.class, io.vertx.groovy.core.buffer.Buffer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.slice(start, end), io.vertx.groovy.core.buffer.Buffer.class);
     return ret;
   }
 }

--- a/src/main/groovy/io/vertx/groovy/core/datagram/DatagramPacket.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/datagram/DatagramPacket.groovy
@@ -24,9 +24,9 @@ import io.vertx.groovy.core.net.SocketAddress
 */
 @CompileStatic
 public class DatagramPacket {
-  final def io.vertx.core.datagram.DatagramPacket delegate;
-  public DatagramPacket(io.vertx.core.datagram.DatagramPacket delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.datagram.DatagramPacket delegate;
+  public DatagramPacket(Object delegate) {
+    this.delegate = (io.vertx.core.datagram.DatagramPacket) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -37,7 +37,7 @@ public class DatagramPacket {
    * @return the address of the sender
    */
   public SocketAddress sender() {
-    def ret= InternalHelper.safeCreate(this.delegate.sender(), io.vertx.core.net.SocketAddress.class, io.vertx.groovy.core.net.SocketAddress.class);
+    def ret= InternalHelper.safeCreate(this.delegate.sender(), io.vertx.groovy.core.net.SocketAddress.class);
     return ret;
   }
   /**
@@ -45,7 +45,7 @@ public class DatagramPacket {
    * @return the data
    */
   public Buffer data() {
-    def ret= InternalHelper.safeCreate(this.delegate.data(), io.vertx.core.buffer.Buffer.class, io.vertx.groovy.core.buffer.Buffer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.data(), io.vertx.groovy.core.buffer.Buffer.class);
     return ret;
   }
 }

--- a/src/main/groovy/io/vertx/groovy/core/datagram/DatagramSocket.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/datagram/DatagramSocket.groovy
@@ -37,9 +37,9 @@ import io.vertx.groovy.core.net.SocketAddress
 */
 @CompileStatic
 public class DatagramSocket implements ReadStream<DatagramPacket>,  Measured {
-  final def io.vertx.core.datagram.DatagramSocket delegate;
-  public DatagramSocket(io.vertx.core.datagram.DatagramSocket delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.datagram.DatagramSocket delegate;
+  public DatagramSocket(Object delegate) {
+    this.delegate = (io.vertx.core.datagram.DatagramSocket) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -83,7 +83,7 @@ public class DatagramSocket implements ReadStream<DatagramPacket>,  Measured {
    * @return the write stream for sending packets
    */
   public PacketWritestream sender(int port, String host) {
-    def ret= InternalHelper.safeCreate(this.delegate.sender(port, host), io.vertx.core.datagram.PacketWritestream.class, io.vertx.groovy.core.datagram.PacketWritestream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.sender(port, host), io.vertx.groovy.core.datagram.PacketWritestream.class);
     return ret;
   }
   /**
@@ -156,7 +156,7 @@ public class DatagramSocket implements ReadStream<DatagramPacket>,  Measured {
     if (cached_0 != null) {
       return cached_0;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.localAddress(), io.vertx.core.net.SocketAddress.class, io.vertx.groovy.core.net.SocketAddress.class);
+    def ret= InternalHelper.safeCreate(this.delegate.localAddress(), io.vertx.groovy.core.net.SocketAddress.class);
     cached_0 = ret;
     return ret;
   }
@@ -315,19 +315,19 @@ public class DatagramSocket implements ReadStream<DatagramPacket>,  Measured {
     return this;
   }
   public DatagramSocket pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.datagram.DatagramSocket) this.delegate).pause();
     return this;
   }
   public DatagramSocket resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.datagram.DatagramSocket) this.delegate).resume();
     return this;
   }
   public DatagramSocket endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.datagram.DatagramSocket) this.delegate).endHandler(endHandler);
     return this;
   }
   public DatagramSocket handler(Handler<DatagramPacket> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.datagram.DatagramPacket>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.datagram.DatagramSocket) this.delegate).handler(new Handler<io.vertx.core.datagram.DatagramPacket>() {
       public void handle(io.vertx.core.datagram.DatagramPacket event) {
         handler.handle(new io.vertx.groovy.core.datagram.DatagramPacket(event));
       }
@@ -335,7 +335,7 @@ public class DatagramSocket implements ReadStream<DatagramPacket>,  Measured {
     return this;
   }
   public DatagramSocket exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.datagram.DatagramSocket) this.delegate).exceptionHandler(handler);
     return this;
   }
   private SocketAddress cached_0;

--- a/src/main/groovy/io/vertx/groovy/core/datagram/PacketWritestream.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/datagram/PacketWritestream.groovy
@@ -26,9 +26,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class PacketWritestream implements WriteStream<Buffer> {
-  final def io.vertx.core.datagram.PacketWritestream delegate;
-  public PacketWritestream(io.vertx.core.datagram.PacketWritestream delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.datagram.PacketWritestream delegate;
+  public PacketWritestream(Object delegate) {
+    this.delegate = (io.vertx.core.datagram.PacketWritestream) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -42,19 +42,19 @@ public class PacketWritestream implements WriteStream<Buffer> {
     return ret;
   }
   public PacketWritestream exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.datagram.PacketWritestream) this.delegate).exceptionHandler(handler);
     return this;
   }
   public PacketWritestream write(Buffer data) {
-    this.delegate.write((io.vertx.core.buffer.Buffer)data.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.datagram.PacketWritestream) this.delegate).write((io.vertx.core.buffer.Buffer)data.getDelegate());
     return this;
   }
   public PacketWritestream setWriteQueueMaxSize(int maxSize) {
-    this.delegate.setWriteQueueMaxSize(maxSize);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.datagram.PacketWritestream) this.delegate).setWriteQueueMaxSize(maxSize);
     return this;
   }
   public PacketWritestream drainHandler(Handler<Void> handler) {
-    this.delegate.drainHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.datagram.PacketWritestream) this.delegate).drainHandler(handler);
     return this;
   }
 }

--- a/src/main/groovy/io/vertx/groovy/core/dns/DnsClient.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/dns/DnsClient.groovy
@@ -27,9 +27,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class DnsClient {
-  final def io.vertx.core.dns.DnsClient delegate;
-  public DnsClient(io.vertx.core.dns.DnsClient delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.dns.DnsClient delegate;
+  public DnsClient(Object delegate) {
+    this.delegate = (io.vertx.core.dns.DnsClient) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/dns/MxRecord.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/dns/MxRecord.groovy
@@ -22,9 +22,9 @@ import io.vertx.lang.groovy.InternalHelper
 */
 @CompileStatic
 public class MxRecord {
-  final def io.vertx.core.dns.MxRecord delegate;
-  public MxRecord(io.vertx.core.dns.MxRecord delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.dns.MxRecord delegate;
+  public MxRecord(Object delegate) {
+    this.delegate = (io.vertx.core.dns.MxRecord) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/dns/SrvRecord.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/dns/SrvRecord.groovy
@@ -22,9 +22,9 @@ import io.vertx.lang.groovy.InternalHelper
 */
 @CompileStatic
 public class SrvRecord {
-  final def io.vertx.core.dns.SrvRecord delegate;
-  public SrvRecord(io.vertx.core.dns.SrvRecord delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.dns.SrvRecord delegate;
+  public SrvRecord(Object delegate) {
+    this.delegate = (io.vertx.core.dns.SrvRecord) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/eventbus/EventBus.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/eventbus/EventBus.groovy
@@ -33,9 +33,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class EventBus implements Measured {
-  final def io.vertx.core.eventbus.EventBus delegate;
-  public EventBus(io.vertx.core.eventbus.EventBus delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.eventbus.EventBus delegate;
+  public EventBus(Object delegate) {
+    this.delegate = (io.vertx.core.eventbus.EventBus) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -148,7 +148,7 @@ public class EventBus implements Measured {
    * @return the event bus message consumer
    */
   public <T> MessageConsumer<T> consumer(String address) {
-    def ret= InternalHelper.safeCreate(this.delegate.consumer(address), io.vertx.core.eventbus.MessageConsumer.class, io.vertx.groovy.core.eventbus.MessageConsumer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.consumer(address), io.vertx.groovy.core.eventbus.MessageConsumer.class);
     return ret;
   }
   /**
@@ -162,7 +162,7 @@ public class EventBus implements Measured {
       public void handle(io.vertx.core.eventbus.Message<java.lang.Object> event) {
         handler.handle(new io.vertx.groovy.core.eventbus.Message(event));
       }
-    }), io.vertx.core.eventbus.MessageConsumer.class, io.vertx.groovy.core.eventbus.MessageConsumer.class);
+    }), io.vertx.groovy.core.eventbus.MessageConsumer.class);
     return ret;
   }
   /**
@@ -171,7 +171,7 @@ public class EventBus implements Measured {
    * @return the event bus message consumer
    */
   public <T> MessageConsumer<T> localConsumer(String address) {
-    def ret= InternalHelper.safeCreate(this.delegate.localConsumer(address), io.vertx.core.eventbus.MessageConsumer.class, io.vertx.groovy.core.eventbus.MessageConsumer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.localConsumer(address), io.vertx.groovy.core.eventbus.MessageConsumer.class);
     return ret;
   }
   /**
@@ -185,7 +185,7 @@ public class EventBus implements Measured {
       public void handle(io.vertx.core.eventbus.Message<java.lang.Object> event) {
         handler.handle(new io.vertx.groovy.core.eventbus.Message(event));
       }
-    }), io.vertx.core.eventbus.MessageConsumer.class, io.vertx.groovy.core.eventbus.MessageConsumer.class);
+    }), io.vertx.groovy.core.eventbus.MessageConsumer.class);
     return ret;
   }
   /**
@@ -198,7 +198,7 @@ public class EventBus implements Measured {
    * @return The sender
    */
   public <T> MessageProducer<T> sender(String address) {
-    def ret= InternalHelper.safeCreate(this.delegate.sender(address), io.vertx.core.eventbus.MessageProducer.class, io.vertx.groovy.core.eventbus.MessageProducer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.sender(address), io.vertx.groovy.core.eventbus.MessageProducer.class);
     return ret;
   }
   /**
@@ -209,7 +209,7 @@ public class EventBus implements Measured {
    * @return The sender
    */
   public <T> MessageProducer<T> sender(String address, Map<String, Object> options) {
-    def ret= InternalHelper.safeCreate(this.delegate.sender(address, options != null ? new io.vertx.core.eventbus.DeliveryOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.core.eventbus.MessageProducer.class, io.vertx.groovy.core.eventbus.MessageProducer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.sender(address, options != null ? new io.vertx.core.eventbus.DeliveryOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.groovy.core.eventbus.MessageProducer.class);
     return ret;
   }
   /**
@@ -222,7 +222,7 @@ public class EventBus implements Measured {
    * @return The publisher
    */
   public <T> MessageProducer<T> publisher(String address) {
-    def ret= InternalHelper.safeCreate(this.delegate.publisher(address), io.vertx.core.eventbus.MessageProducer.class, io.vertx.groovy.core.eventbus.MessageProducer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.publisher(address), io.vertx.groovy.core.eventbus.MessageProducer.class);
     return ret;
   }
   /**
@@ -233,7 +233,7 @@ public class EventBus implements Measured {
    * @return The publisher
    */
   public <T> MessageProducer<T> publisher(String address, Map<String, Object> options) {
-    def ret= InternalHelper.safeCreate(this.delegate.publisher(address, options != null ? new io.vertx.core.eventbus.DeliveryOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.core.eventbus.MessageProducer.class, io.vertx.groovy.core.eventbus.MessageProducer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.publisher(address, options != null ? new io.vertx.core.eventbus.DeliveryOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.groovy.core.eventbus.MessageProducer.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/eventbus/Message.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/eventbus/Message.groovy
@@ -33,9 +33,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class Message<T> {
-  final def io.vertx.core.eventbus.Message delegate;
-  public Message(io.vertx.core.eventbus.Message delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.eventbus.Message delegate;
+  public Message(Object delegate) {
+    this.delegate = (io.vertx.core.eventbus.Message) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -53,7 +53,7 @@ public class Message<T> {
    * @return the headers
    */
   public MultiMap headers() {
-    def ret= InternalHelper.safeCreate(((io.vertx.core.eventbus.Message) this.delegate).headers(), io.vertx.core.MultiMap.class, io.vertx.groovy.core.MultiMap.class);
+    def ret= InternalHelper.safeCreate(((io.vertx.core.eventbus.Message) this.delegate).headers(), io.vertx.groovy.core.MultiMap.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/eventbus/MessageConsumer.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/eventbus/MessageConsumer.groovy
@@ -33,19 +33,19 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class MessageConsumer<T> implements ReadStream<Message<T>> {
-  final def io.vertx.core.eventbus.MessageConsumer delegate;
-  public MessageConsumer(io.vertx.core.eventbus.MessageConsumer delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.eventbus.MessageConsumer delegate;
+  public MessageConsumer(Object delegate) {
+    this.delegate = (io.vertx.core.eventbus.MessageConsumer) delegate;
   }
   public Object getDelegate() {
     return delegate;
   }
   public MessageConsumer<T> exceptionHandler(Handler<Throwable> handler) {
-    ((io.vertx.core.eventbus.MessageConsumer) this.delegate).exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.StreamBase) this.delegate).exceptionHandler(handler);
     return this;
   }
   public MessageConsumer<T> handler(Handler<Message<T>> handler) {
-    ((io.vertx.core.eventbus.MessageConsumer) this.delegate).handler(new Handler<io.vertx.core.eventbus.Message<java.lang.Object>>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.ReadStream) this.delegate).handler(new Handler<io.vertx.core.eventbus.Message<java.lang.Object>>() {
       public void handle(io.vertx.core.eventbus.Message<java.lang.Object> event) {
         handler.handle(new io.vertx.groovy.core.eventbus.Message(event));
       }
@@ -53,15 +53,15 @@ public class MessageConsumer<T> implements ReadStream<Message<T>> {
     return this;
   }
   public MessageConsumer<T> pause() {
-    ((io.vertx.core.eventbus.MessageConsumer) this.delegate).pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.ReadStream) this.delegate).pause();
     return this;
   }
   public MessageConsumer<T> resume() {
-    ((io.vertx.core.eventbus.MessageConsumer) this.delegate).resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.ReadStream) this.delegate).resume();
     return this;
   }
   public MessageConsumer<T> endHandler(Handler<Void> endHandler) {
-    ((io.vertx.core.eventbus.MessageConsumer) this.delegate).endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.ReadStream) this.delegate).endHandler(endHandler);
     return this;
   }
   /**
@@ -69,7 +69,7 @@ public class MessageConsumer<T> implements ReadStream<Message<T>> {
    * @return 
    */
   public ReadStream<T> bodyStream() {
-    def ret= InternalHelper.safeCreate(((io.vertx.core.eventbus.MessageConsumer) this.delegate).bodyStream(), io.vertx.core.streams.ReadStream.class, io.vertx.groovy.core.streams.ReadStreamImpl.class);
+    def ret= InternalHelper.safeCreate(((io.vertx.core.eventbus.MessageConsumer) this.delegate).bodyStream(), io.vertx.groovy.core.streams.ReadStreamImpl.class);
     return ret;
   }
   /**
@@ -96,7 +96,7 @@ public class MessageConsumer<T> implements ReadStream<Message<T>> {
    * @return this registration
    */
   public MessageConsumer<T> setMaxBufferedMessages(int maxBufferedMessages) {
-    def ret= InternalHelper.safeCreate(((io.vertx.core.eventbus.MessageConsumer) this.delegate).setMaxBufferedMessages(maxBufferedMessages), io.vertx.core.eventbus.MessageConsumer.class, io.vertx.groovy.core.eventbus.MessageConsumer.class);
+    def ret= InternalHelper.safeCreate(((io.vertx.core.eventbus.MessageConsumer) this.delegate).setMaxBufferedMessages(maxBufferedMessages), io.vertx.groovy.core.eventbus.MessageConsumer.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/eventbus/MessageProducer.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/eventbus/MessageProducer.groovy
@@ -26,9 +26,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class MessageProducer<T> implements WriteStream<T> {
-  final def io.vertx.core.eventbus.MessageProducer delegate;
-  public MessageProducer(io.vertx.core.eventbus.MessageProducer delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.eventbus.MessageProducer delegate;
+  public MessageProducer(Object delegate) {
+    this.delegate = (io.vertx.core.eventbus.MessageProducer) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -42,19 +42,19 @@ public class MessageProducer<T> implements WriteStream<T> {
     return ret;
   }
   public MessageProducer<T> exceptionHandler(Handler<Throwable> handler) {
-    ((io.vertx.core.eventbus.MessageProducer) this.delegate).exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.WriteStream) this.delegate).exceptionHandler(handler);
     return this;
   }
   public MessageProducer<T> write(T data) {
-    ((io.vertx.core.eventbus.MessageProducer) this.delegate).write(InternalHelper.unwrapObject(data));
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.WriteStream) this.delegate).write(InternalHelper.unwrapObject(data));
     return this;
   }
   public MessageProducer<T> setWriteQueueMaxSize(int maxSize) {
-    ((io.vertx.core.eventbus.MessageProducer) this.delegate).setWriteQueueMaxSize(maxSize);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.WriteStream) this.delegate).setWriteQueueMaxSize(maxSize);
     return this;
   }
   public MessageProducer<T> drainHandler(Handler<Void> handler) {
-    ((io.vertx.core.eventbus.MessageProducer) this.delegate).drainHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.WriteStream) this.delegate).drainHandler(handler);
     return this;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/file/AsyncFile.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/file/AsyncFile.groovy
@@ -32,9 +32,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class AsyncFile implements ReadStream<Buffer>,  WriteStream<Buffer> {
-  final def io.vertx.core.file.AsyncFile delegate;
-  public AsyncFile(io.vertx.core.file.AsyncFile delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.file.AsyncFile delegate;
+  public AsyncFile(Object delegate) {
+    this.delegate = (io.vertx.core.file.AsyncFile) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -48,7 +48,7 @@ public class AsyncFile implements ReadStream<Buffer>,  WriteStream<Buffer> {
     return ret;
   }
   public AsyncFile handler(Handler<Buffer> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.buffer.Buffer>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.file.AsyncFile) this.delegate).handler(new Handler<io.vertx.core.buffer.Buffer>() {
       public void handle(io.vertx.core.buffer.Buffer event) {
         handler.handle(new io.vertx.groovy.core.buffer.Buffer(event));
       }
@@ -56,31 +56,31 @@ public class AsyncFile implements ReadStream<Buffer>,  WriteStream<Buffer> {
     return this;
   }
   public AsyncFile pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.file.AsyncFile) this.delegate).pause();
     return this;
   }
   public AsyncFile resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.file.AsyncFile) this.delegate).resume();
     return this;
   }
   public AsyncFile endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.file.AsyncFile) this.delegate).endHandler(endHandler);
     return this;
   }
   public AsyncFile write(Buffer data) {
-    this.delegate.write((io.vertx.core.buffer.Buffer)data.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.file.AsyncFile) this.delegate).write((io.vertx.core.buffer.Buffer)data.getDelegate());
     return this;
   }
   public AsyncFile setWriteQueueMaxSize(int maxSize) {
-    this.delegate.setWriteQueueMaxSize(maxSize);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.file.AsyncFile) this.delegate).setWriteQueueMaxSize(maxSize);
     return this;
   }
   public AsyncFile drainHandler(Handler<Void> handler) {
-    this.delegate.drainHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.file.AsyncFile) this.delegate).drainHandler(handler);
     return this;
   }
   public AsyncFile exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.file.AsyncFile) this.delegate).exceptionHandler(handler);
     return this;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/file/FileProps.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/file/FileProps.groovy
@@ -23,9 +23,9 @@ import io.vertx.lang.groovy.InternalHelper
 */
 @CompileStatic
 public class FileProps {
-  final def io.vertx.core.file.FileProps delegate;
-  public FileProps(io.vertx.core.file.FileProps delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.file.FileProps delegate;
+  public FileProps(Object delegate) {
+    this.delegate = (io.vertx.core.file.FileProps) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/file/FileSystem.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/file/FileSystem.groovy
@@ -38,9 +38,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class FileSystem {
-  final def io.vertx.core.file.FileSystem delegate;
-  public FileSystem(io.vertx.core.file.FileSystem delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.file.FileSystem delegate;
+  public FileSystem(Object delegate) {
+    this.delegate = (io.vertx.core.file.FileSystem) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -246,7 +246,7 @@ public class FileSystem {
    * @return 
    */
   public FileProps propsBlocking(String path) {
-    def ret= InternalHelper.safeCreate(this.delegate.propsBlocking(path), io.vertx.core.file.FileProps.class, io.vertx.groovy.core.file.FileProps.class);
+    def ret= InternalHelper.safeCreate(this.delegate.propsBlocking(path), io.vertx.groovy.core.file.FileProps.class);
     return ret;
   }
   /**
@@ -277,7 +277,7 @@ public class FileSystem {
    * @return 
    */
   public FileProps lpropsBlocking(String path) {
-    def ret= InternalHelper.safeCreate(this.delegate.lpropsBlocking(path), io.vertx.core.file.FileProps.class, io.vertx.groovy.core.file.FileProps.class);
+    def ret= InternalHelper.safeCreate(this.delegate.lpropsBlocking(path), io.vertx.groovy.core.file.FileProps.class);
     return ret;
   }
   /**
@@ -576,7 +576,7 @@ public class FileSystem {
    * @return 
    */
   public Buffer readFileBlocking(String path) {
-    def ret= InternalHelper.safeCreate(this.delegate.readFileBlocking(path), io.vertx.core.buffer.Buffer.class, io.vertx.groovy.core.buffer.Buffer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.readFileBlocking(path), io.vertx.groovy.core.buffer.Buffer.class);
     return ret;
   }
   /**
@@ -631,7 +631,7 @@ public class FileSystem {
    * @return 
    */
   public AsyncFile openBlocking(String path, Map<String, Object> options) {
-    def ret= InternalHelper.safeCreate(this.delegate.openBlocking(path, options != null ? new io.vertx.core.file.OpenOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.core.file.AsyncFile.class, io.vertx.groovy.core.file.AsyncFile.class);
+    def ret= InternalHelper.safeCreate(this.delegate.openBlocking(path, options != null ? new io.vertx.core.file.OpenOptions(new io.vertx.core.json.JsonObject(options)) : null), io.vertx.groovy.core.file.AsyncFile.class);
     return ret;
   }
   /**
@@ -719,7 +719,7 @@ public class FileSystem {
    * @return 
    */
   public FileSystemProps fsPropsBlocking(String path) {
-    def ret= InternalHelper.safeCreate(this.delegate.fsPropsBlocking(path), io.vertx.core.file.FileSystemProps.class, io.vertx.groovy.core.file.FileSystemProps.class);
+    def ret= InternalHelper.safeCreate(this.delegate.fsPropsBlocking(path), io.vertx.groovy.core.file.FileSystemProps.class);
     return ret;
   }
 }

--- a/src/main/groovy/io/vertx/groovy/core/file/FileSystemProps.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/file/FileSystemProps.groovy
@@ -22,9 +22,9 @@ import io.vertx.lang.groovy.InternalHelper
 */
 @CompileStatic
 public class FileSystemProps {
-  final def io.vertx.core.file.FileSystemProps delegate;
-  public FileSystemProps(io.vertx.core.file.FileSystemProps delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.file.FileSystemProps delegate;
+  public FileSystemProps(Object delegate) {
+    this.delegate = (io.vertx.core.file.FileSystemProps) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/http/HttpClient.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/HttpClient.groovy
@@ -50,9 +50,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class HttpClient implements Measured {
-  final def io.vertx.core.http.HttpClient delegate;
-  public HttpClient(io.vertx.core.http.HttpClient delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.HttpClient delegate;
+  public HttpClient(Object delegate) {
+    this.delegate = (io.vertx.core.http.HttpClient) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -74,7 +74,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest request(HttpMethod method, int port, String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.request(method, port, host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.request(method, port, host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -85,7 +85,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest request(HttpMethod method, String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.request(method, host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.request(method, host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -103,7 +103,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -120,7 +120,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -130,7 +130,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest request(HttpMethod method, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.request(method, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.request(method, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -146,7 +146,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -156,7 +156,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest requestAbs(HttpMethod method, String absoluteURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.requestAbs(method, absoluteURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.requestAbs(method, absoluteURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -172,7 +172,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -183,7 +183,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest get(int port, String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.get(port, host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.get(port, host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -193,7 +193,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest get(String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.get(host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.get(host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -210,7 +210,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -226,7 +226,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -235,7 +235,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest get(String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.get(requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.get(requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -250,7 +250,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -259,7 +259,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest getAbs(String absoluteURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.getAbs(absoluteURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.getAbs(absoluteURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -274,7 +274,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -291,7 +291,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -307,7 +307,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -322,7 +322,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -333,7 +333,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest post(int port, String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.post(port, host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.post(port, host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -343,7 +343,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest post(String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.post(host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.post(host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -360,7 +360,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -376,7 +376,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -385,7 +385,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest post(String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.post(requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.post(requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -400,7 +400,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -409,7 +409,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest postAbs(String absoluteURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.postAbs(absoluteURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.postAbs(absoluteURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -424,7 +424,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -435,7 +435,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest head(int port, String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.head(port, host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.head(port, host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -445,7 +445,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest head(String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.head(host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.head(host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -462,7 +462,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -478,7 +478,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -487,7 +487,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest head(String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.head(requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.head(requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -502,7 +502,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -511,7 +511,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest headAbs(String absoluteURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.headAbs(absoluteURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.headAbs(absoluteURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -526,7 +526,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -543,7 +543,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -559,7 +559,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -574,7 +574,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -585,7 +585,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest options(int port, String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.options(port, host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.options(port, host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -595,7 +595,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest options(String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.options(host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.options(host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -612,7 +612,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -628,7 +628,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -637,7 +637,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest options(String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.options(requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.options(requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -652,7 +652,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -661,7 +661,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest optionsAbs(String absoluteURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.optionsAbs(absoluteURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.optionsAbs(absoluteURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -676,7 +676,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -693,7 +693,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -709,7 +709,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -724,7 +724,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -735,7 +735,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest put(int port, String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.put(port, host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.put(port, host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -745,7 +745,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest put(String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.put(host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.put(host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -762,7 +762,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -778,7 +778,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -787,7 +787,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest put(String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.put(requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.put(requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -802,7 +802,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -811,7 +811,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest putAbs(String absoluteURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.putAbs(absoluteURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.putAbs(absoluteURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -826,7 +826,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -837,7 +837,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest delete(int port, String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.delete(port, host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.delete(port, host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -847,7 +847,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest delete(String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.delete(host, requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.delete(host, requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -864,7 +864,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -880,7 +880,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -889,7 +889,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest delete(String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.delete(requestURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.delete(requestURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -904,7 +904,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -913,7 +913,7 @@ public class HttpClient implements Measured {
    * @return an HTTP client request object
    */
   public HttpClientRequest deleteAbs(String absoluteURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.deleteAbs(absoluteURI), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    def ret= InternalHelper.safeCreate(this.delegate.deleteAbs(absoluteURI), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -928,7 +928,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         responseHandler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
-    }), io.vertx.core.http.HttpClientRequest.class, io.vertx.groovy.core.http.HttpClientRequest.class);
+    }), io.vertx.groovy.core.http.HttpClientRequest.class);
     return ret;
   }
   /**
@@ -944,7 +944,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.WebSocket event) {
         wsConnect.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -959,7 +959,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.WebSocket event) {
         wsConnect.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -976,7 +976,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.WebSocket event) {
         wsConnect.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -992,7 +992,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.WebSocket event) {
         wsConnect.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -1011,7 +1011,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.WebSocket event) {
         wsConnect.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -1029,7 +1029,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.WebSocket event) {
         wsConnect.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -1049,7 +1049,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.WebSocket event) {
         wsConnect.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -1068,7 +1068,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.WebSocket event) {
         wsConnect.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -1082,7 +1082,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.WebSocket event) {
         wsConnect.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -1097,7 +1097,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.WebSocket event) {
         wsConnect.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -1114,7 +1114,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.WebSocket event) {
         wsConnect.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -1132,7 +1132,7 @@ public class HttpClient implements Measured {
       public void handle(io.vertx.core.http.WebSocket event) {
         wsConnect.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
-    }), io.vertx.core.http.HttpClient.class, io.vertx.groovy.core.http.HttpClient.class);
+    }), io.vertx.groovy.core.http.HttpClient.class);
     return ret;
   }
   /**
@@ -1143,7 +1143,7 @@ public class HttpClient implements Measured {
    * @return a reference to this, so the API can be used fluently
    */
   public WebSocketStream websocketStream(int port, String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(port, host, requestURI), io.vertx.core.http.WebSocketStream.class, io.vertx.groovy.core.http.WebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(port, host, requestURI), io.vertx.groovy.core.http.WebSocketStream.class);
     return ret;
   }
   /**
@@ -1153,7 +1153,7 @@ public class HttpClient implements Measured {
    * @return a reference to this, so the API can be used fluently
    */
   public WebSocketStream websocketStream(String host, String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(host, requestURI), io.vertx.core.http.WebSocketStream.class, io.vertx.groovy.core.http.WebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(host, requestURI), io.vertx.groovy.core.http.WebSocketStream.class);
     return ret;
   }
   /**
@@ -1165,7 +1165,7 @@ public class HttpClient implements Measured {
    * @return a reference to this, so the API can be used fluently
    */
   public WebSocketStream websocketStream(int port, String host, String requestURI, MultiMap headers) {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(port, host, requestURI, (io.vertx.core.MultiMap)headers.getDelegate()), io.vertx.core.http.WebSocketStream.class, io.vertx.groovy.core.http.WebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(port, host, requestURI, (io.vertx.core.MultiMap)headers.getDelegate()), io.vertx.groovy.core.http.WebSocketStream.class);
     return ret;
   }
   /**
@@ -1176,7 +1176,7 @@ public class HttpClient implements Measured {
    * @return a reference to this, so the API can be used fluently
    */
   public WebSocketStream websocketStream(String host, String requestURI, MultiMap headers) {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(host, requestURI, (io.vertx.core.MultiMap)headers.getDelegate()), io.vertx.core.http.WebSocketStream.class, io.vertx.groovy.core.http.WebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(host, requestURI, (io.vertx.core.MultiMap)headers.getDelegate()), io.vertx.groovy.core.http.WebSocketStream.class);
     return ret;
   }
   /**
@@ -1190,7 +1190,7 @@ public class HttpClient implements Measured {
    * @return a reference to this, so the API can be used fluently
    */
   public WebSocketStream websocketStream(int port, String host, String requestURI, MultiMap headers, WebsocketVersion version) {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(port, host, requestURI, (io.vertx.core.MultiMap)headers.getDelegate(), version), io.vertx.core.http.WebSocketStream.class, io.vertx.groovy.core.http.WebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(port, host, requestURI, (io.vertx.core.MultiMap)headers.getDelegate(), version), io.vertx.groovy.core.http.WebSocketStream.class);
     return ret;
   }
   /**
@@ -1203,7 +1203,7 @@ public class HttpClient implements Measured {
    * @return a reference to this, so the API can be used fluently
    */
   public WebSocketStream websocketStream(String host, String requestURI, MultiMap headers, WebsocketVersion version) {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(host, requestURI, (io.vertx.core.MultiMap)headers.getDelegate(), version), io.vertx.core.http.WebSocketStream.class, io.vertx.groovy.core.http.WebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(host, requestURI, (io.vertx.core.MultiMap)headers.getDelegate(), version), io.vertx.groovy.core.http.WebSocketStream.class);
     return ret;
   }
   /**
@@ -1218,7 +1218,7 @@ public class HttpClient implements Measured {
    * @return a reference to this, so the API can be used fluently
    */
   public WebSocketStream websocketStream(int port, String host, String requestURI, MultiMap headers, WebsocketVersion version, String subProtocols) {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(port, host, requestURI, (io.vertx.core.MultiMap)headers.getDelegate(), version, subProtocols), io.vertx.core.http.WebSocketStream.class, io.vertx.groovy.core.http.WebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(port, host, requestURI, (io.vertx.core.MultiMap)headers.getDelegate(), version, subProtocols), io.vertx.groovy.core.http.WebSocketStream.class);
     return ret;
   }
   /**
@@ -1232,7 +1232,7 @@ public class HttpClient implements Measured {
    * @return a reference to this, so the API can be used fluently
    */
   public WebSocketStream websocketStream(String host, String requestURI, MultiMap headers, WebsocketVersion version, String subProtocols) {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(host, requestURI, (io.vertx.core.MultiMap)headers.getDelegate(), version, subProtocols), io.vertx.core.http.WebSocketStream.class, io.vertx.groovy.core.http.WebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(host, requestURI, (io.vertx.core.MultiMap)headers.getDelegate(), version, subProtocols), io.vertx.groovy.core.http.WebSocketStream.class);
     return ret;
   }
   /**
@@ -1241,7 +1241,7 @@ public class HttpClient implements Measured {
    * @return a reference to this, so the API can be used fluently
    */
   public WebSocketStream websocketStream(String requestURI) {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(requestURI), io.vertx.core.http.WebSocketStream.class, io.vertx.groovy.core.http.WebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(requestURI), io.vertx.groovy.core.http.WebSocketStream.class);
     return ret;
   }
   /**
@@ -1251,7 +1251,7 @@ public class HttpClient implements Measured {
    * @return a reference to this, so the API can be used fluently
    */
   public WebSocketStream websocketStream(String requestURI, MultiMap headers) {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(requestURI, (io.vertx.core.MultiMap)headers.getDelegate()), io.vertx.core.http.WebSocketStream.class, io.vertx.groovy.core.http.WebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(requestURI, (io.vertx.core.MultiMap)headers.getDelegate()), io.vertx.groovy.core.http.WebSocketStream.class);
     return ret;
   }
   /**
@@ -1263,7 +1263,7 @@ public class HttpClient implements Measured {
    * @return a reference to this, so the API can be used fluently
    */
   public WebSocketStream websocketStream(String requestURI, MultiMap headers, WebsocketVersion version) {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(requestURI, (io.vertx.core.MultiMap)headers.getDelegate(), version), io.vertx.core.http.WebSocketStream.class, io.vertx.groovy.core.http.WebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(requestURI, (io.vertx.core.MultiMap)headers.getDelegate(), version), io.vertx.groovy.core.http.WebSocketStream.class);
     return ret;
   }
   /**
@@ -1276,7 +1276,7 @@ public class HttpClient implements Measured {
    * @return a reference to this, so the API can be used fluently
    */
   public WebSocketStream websocketStream(String requestURI, MultiMap headers, WebsocketVersion version, String subProtocols) {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(requestURI, (io.vertx.core.MultiMap)headers.getDelegate(), version, subProtocols), io.vertx.core.http.WebSocketStream.class, io.vertx.groovy.core.http.WebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(requestURI, (io.vertx.core.MultiMap)headers.getDelegate(), version, subProtocols), io.vertx.groovy.core.http.WebSocketStream.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/http/HttpClientRequest.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/HttpClientRequest.groovy
@@ -52,9 +52,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class HttpClientRequest implements WriteStream<Buffer>,  ReadStream<HttpClientResponse> {
-  final def io.vertx.core.http.HttpClientRequest delegate;
-  public HttpClientRequest(io.vertx.core.http.HttpClientRequest delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.HttpClientRequest delegate;
+  public HttpClientRequest(Object delegate) {
+    this.delegate = (io.vertx.core.http.HttpClientRequest) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -68,7 +68,7 @@ public class HttpClientRequest implements WriteStream<Buffer>,  ReadStream<HttpC
     return ret;
   }
   public HttpClientRequest exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientRequest) this.delegate).exceptionHandler(handler);
     return this;
   }
   /**
@@ -77,19 +77,19 @@ public class HttpClientRequest implements WriteStream<Buffer>,  ReadStream<HttpC
    * @return 
    */
   public HttpClientRequest write(Buffer data) {
-    this.delegate.write((io.vertx.core.buffer.Buffer)data.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientRequest) this.delegate).write((io.vertx.core.buffer.Buffer)data.getDelegate());
     return this;
   }
   public HttpClientRequest setWriteQueueMaxSize(int maxSize) {
-    this.delegate.setWriteQueueMaxSize(maxSize);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientRequest) this.delegate).setWriteQueueMaxSize(maxSize);
     return this;
   }
   public HttpClientRequest drainHandler(Handler<Void> handler) {
-    this.delegate.drainHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientRequest) this.delegate).drainHandler(handler);
     return this;
   }
   public HttpClientRequest handler(Handler<HttpClientResponse> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.http.HttpClientResponse>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientRequest) this.delegate).handler(new Handler<io.vertx.core.http.HttpClientResponse>() {
       public void handle(io.vertx.core.http.HttpClientResponse event) {
         handler.handle(new io.vertx.groovy.core.http.HttpClientResponse(event));
       }
@@ -97,15 +97,15 @@ public class HttpClientRequest implements WriteStream<Buffer>,  ReadStream<HttpC
     return this;
   }
   public HttpClientRequest pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientRequest) this.delegate).pause();
     return this;
   }
   public HttpClientRequest resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientRequest) this.delegate).resume();
     return this;
   }
   public HttpClientRequest endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientRequest) this.delegate).endHandler(endHandler);
     return this;
   }
   /**
@@ -149,7 +149,7 @@ public class HttpClientRequest implements WriteStream<Buffer>,  ReadStream<HttpC
     if (cached_0 != null) {
       return cached_0;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.headers(), io.vertx.core.MultiMap.class, io.vertx.groovy.core.MultiMap.class);
+    def ret= InternalHelper.safeCreate(this.delegate.headers(), io.vertx.groovy.core.MultiMap.class);
     cached_0 = ret;
     return ret;
   }

--- a/src/main/groovy/io/vertx/groovy/core/http/HttpClientResponse.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/HttpClientResponse.groovy
@@ -34,23 +34,23 @@ import io.vertx.groovy.core.net.NetSocket
 */
 @CompileStatic
 public class HttpClientResponse implements ReadStream<Buffer> {
-  final def io.vertx.core.http.HttpClientResponse delegate;
-  public HttpClientResponse(io.vertx.core.http.HttpClientResponse delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.HttpClientResponse delegate;
+  public HttpClientResponse(Object delegate) {
+    this.delegate = (io.vertx.core.http.HttpClientResponse) delegate;
   }
   public Object getDelegate() {
     return delegate;
   }
   public HttpClientResponse resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientResponse) this.delegate).resume();
     return this;
   }
   public HttpClientResponse exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientResponse) this.delegate).exceptionHandler(handler);
     return this;
   }
   public HttpClientResponse handler(Handler<Buffer> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.buffer.Buffer>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientResponse) this.delegate).handler(new Handler<io.vertx.core.buffer.Buffer>() {
       public void handle(io.vertx.core.buffer.Buffer event) {
         handler.handle(new io.vertx.groovy.core.buffer.Buffer(event));
       }
@@ -58,11 +58,11 @@ public class HttpClientResponse implements ReadStream<Buffer> {
     return this;
   }
   public HttpClientResponse pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientResponse) this.delegate).pause();
     return this;
   }
   public HttpClientResponse endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpClientResponse) this.delegate).endHandler(endHandler);
     return this;
   }
   /**
@@ -89,7 +89,7 @@ public class HttpClientResponse implements ReadStream<Buffer> {
     if (cached_0 != null) {
       return cached_0;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.headers(), io.vertx.core.MultiMap.class, io.vertx.groovy.core.MultiMap.class);
+    def ret= InternalHelper.safeCreate(this.delegate.headers(), io.vertx.groovy.core.MultiMap.class);
     cached_0 = ret;
     return ret;
   }
@@ -119,7 +119,7 @@ public class HttpClientResponse implements ReadStream<Buffer> {
     if (cached_1 != null) {
       return cached_1;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.trailers(), io.vertx.core.MultiMap.class, io.vertx.groovy.core.MultiMap.class);
+    def ret= InternalHelper.safeCreate(this.delegate.trailers(), io.vertx.groovy.core.MultiMap.class);
     cached_1 = ret;
     return ret;
   }
@@ -164,7 +164,7 @@ public class HttpClientResponse implements ReadStream<Buffer> {
     if (cached_3 != null) {
       return cached_3;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.netSocket(), io.vertx.core.net.NetSocket.class, io.vertx.groovy.core.net.NetSocket.class);
+    def ret= InternalHelper.safeCreate(this.delegate.netSocket(), io.vertx.groovy.core.net.NetSocket.class);
     cached_3 = ret;
     return ret;
   }

--- a/src/main/groovy/io/vertx/groovy/core/http/HttpServer.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/HttpServer.groovy
@@ -31,9 +31,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class HttpServer implements Measured {
-  final def io.vertx.core.http.HttpServer delegate;
-  public HttpServer(io.vertx.core.http.HttpServer delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.HttpServer delegate;
+  public HttpServer(Object delegate) {
+    this.delegate = (io.vertx.core.http.HttpServer) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -52,7 +52,7 @@ public class HttpServer implements Measured {
    * @return the request stream
    */
   public HttpServerRequestStream requestStream() {
-    def ret= InternalHelper.safeCreate(this.delegate.requestStream(), io.vertx.core.http.HttpServerRequestStream.class, io.vertx.groovy.core.http.HttpServerRequestStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.requestStream(), io.vertx.groovy.core.http.HttpServerRequestStream.class);
     return ret;
   }
   /**
@@ -66,7 +66,7 @@ public class HttpServer implements Measured {
       public void handle(io.vertx.core.http.HttpServerRequest event) {
         handler.handle(new io.vertx.groovy.core.http.HttpServerRequest(event));
       }
-    }), io.vertx.core.http.HttpServer.class, io.vertx.groovy.core.http.HttpServer.class);
+    }), io.vertx.groovy.core.http.HttpServer.class);
     return ret;
   }
   /**
@@ -75,7 +75,7 @@ public class HttpServer implements Measured {
    * @return the websocket stream
    */
   public ServerWebSocketStream websocketStream() {
-    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(), io.vertx.core.http.ServerWebSocketStream.class, io.vertx.groovy.core.http.ServerWebSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.websocketStream(), io.vertx.groovy.core.http.ServerWebSocketStream.class);
     return ret;
   }
   /**
@@ -89,7 +89,7 @@ public class HttpServer implements Measured {
       public void handle(io.vertx.core.http.ServerWebSocket event) {
         handler.handle(new io.vertx.groovy.core.http.ServerWebSocket(event));
       }
-    }), io.vertx.core.http.HttpServer.class, io.vertx.groovy.core.http.HttpServer.class);
+    }), io.vertx.groovy.core.http.HttpServer.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/http/HttpServerFileUpload.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/HttpServerFileUpload.groovy
@@ -25,19 +25,19 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class HttpServerFileUpload implements ReadStream<Buffer> {
-  final def io.vertx.core.http.HttpServerFileUpload delegate;
-  public HttpServerFileUpload(io.vertx.core.http.HttpServerFileUpload delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.HttpServerFileUpload delegate;
+  public HttpServerFileUpload(Object delegate) {
+    this.delegate = (io.vertx.core.http.HttpServerFileUpload) delegate;
   }
   public Object getDelegate() {
     return delegate;
   }
   public HttpServerFileUpload exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerFileUpload) this.delegate).exceptionHandler(handler);
     return this;
   }
   public HttpServerFileUpload handler(Handler<Buffer> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.buffer.Buffer>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerFileUpload) this.delegate).handler(new Handler<io.vertx.core.buffer.Buffer>() {
       public void handle(io.vertx.core.buffer.Buffer event) {
         handler.handle(new io.vertx.groovy.core.buffer.Buffer(event));
       }
@@ -45,15 +45,15 @@ public class HttpServerFileUpload implements ReadStream<Buffer> {
     return this;
   }
   public HttpServerFileUpload endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerFileUpload) this.delegate).endHandler(endHandler);
     return this;
   }
   public HttpServerFileUpload pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerFileUpload) this.delegate).pause();
     return this;
   }
   public HttpServerFileUpload resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerFileUpload) this.delegate).resume();
     return this;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/http/HttpServerRequest.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/HttpServerRequest.groovy
@@ -38,19 +38,19 @@ import io.vertx.groovy.core.net.NetSocket
 */
 @CompileStatic
 public class HttpServerRequest implements ReadStream<Buffer> {
-  final def io.vertx.core.http.HttpServerRequest delegate;
-  public HttpServerRequest(io.vertx.core.http.HttpServerRequest delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.HttpServerRequest delegate;
+  public HttpServerRequest(Object delegate) {
+    this.delegate = (io.vertx.core.http.HttpServerRequest) delegate;
   }
   public Object getDelegate() {
     return delegate;
   }
   public HttpServerRequest exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerRequest) this.delegate).exceptionHandler(handler);
     return this;
   }
   public HttpServerRequest handler(Handler<Buffer> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.buffer.Buffer>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerRequest) this.delegate).handler(new Handler<io.vertx.core.buffer.Buffer>() {
       public void handle(io.vertx.core.buffer.Buffer event) {
         handler.handle(new io.vertx.groovy.core.buffer.Buffer(event));
       }
@@ -58,15 +58,15 @@ public class HttpServerRequest implements ReadStream<Buffer> {
     return this;
   }
   public HttpServerRequest pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerRequest) this.delegate).pause();
     return this;
   }
   public HttpServerRequest resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerRequest) this.delegate).resume();
     return this;
   }
   public HttpServerRequest endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerRequest) this.delegate).endHandler(endHandler);
     return this;
   }
   /**
@@ -118,7 +118,7 @@ public class HttpServerRequest implements ReadStream<Buffer> {
     if (cached_0 != null) {
       return cached_0;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.response(), io.vertx.core.http.HttpServerResponse.class, io.vertx.groovy.core.http.HttpServerResponse.class);
+    def ret= InternalHelper.safeCreate(this.delegate.response(), io.vertx.groovy.core.http.HttpServerResponse.class);
     cached_0 = ret;
     return ret;
   }
@@ -130,7 +130,7 @@ public class HttpServerRequest implements ReadStream<Buffer> {
     if (cached_1 != null) {
       return cached_1;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.headers(), io.vertx.core.MultiMap.class, io.vertx.groovy.core.MultiMap.class);
+    def ret= InternalHelper.safeCreate(this.delegate.headers(), io.vertx.groovy.core.MultiMap.class);
     cached_1 = ret;
     return ret;
   }
@@ -151,7 +151,7 @@ public class HttpServerRequest implements ReadStream<Buffer> {
     if (cached_2 != null) {
       return cached_2;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.params(), io.vertx.core.MultiMap.class, io.vertx.groovy.core.MultiMap.class);
+    def ret= InternalHelper.safeCreate(this.delegate.params(), io.vertx.groovy.core.MultiMap.class);
     cached_2 = ret;
     return ret;
   }
@@ -172,7 +172,7 @@ public class HttpServerRequest implements ReadStream<Buffer> {
     if (cached_3 != null) {
       return cached_3;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.remoteAddress(), io.vertx.core.net.SocketAddress.class, io.vertx.groovy.core.net.SocketAddress.class);
+    def ret= InternalHelper.safeCreate(this.delegate.remoteAddress(), io.vertx.groovy.core.net.SocketAddress.class);
     cached_3 = ret;
     return ret;
   }
@@ -184,7 +184,7 @@ public class HttpServerRequest implements ReadStream<Buffer> {
     if (cached_4 != null) {
       return cached_4;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.localAddress(), io.vertx.core.net.SocketAddress.class, io.vertx.groovy.core.net.SocketAddress.class);
+    def ret= InternalHelper.safeCreate(this.delegate.localAddress(), io.vertx.groovy.core.net.SocketAddress.class);
     cached_4 = ret;
     return ret;
   }
@@ -226,7 +226,7 @@ public class HttpServerRequest implements ReadStream<Buffer> {
     if (cached_5 != null) {
       return cached_5;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.netSocket(), io.vertx.core.net.NetSocket.class, io.vertx.groovy.core.net.NetSocket.class);
+    def ret= InternalHelper.safeCreate(this.delegate.netSocket(), io.vertx.groovy.core.net.NetSocket.class);
     cached_5 = ret;
     return ret;
   }
@@ -275,7 +275,7 @@ public class HttpServerRequest implements ReadStream<Buffer> {
     if (cached_6 != null) {
       return cached_6;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.formAttributes(), io.vertx.core.MultiMap.class, io.vertx.groovy.core.MultiMap.class);
+    def ret= InternalHelper.safeCreate(this.delegate.formAttributes(), io.vertx.groovy.core.MultiMap.class);
     cached_6 = ret;
     return ret;
   }
@@ -296,7 +296,7 @@ public class HttpServerRequest implements ReadStream<Buffer> {
    * @return the WebSocket
    */
   public ServerWebSocket upgrade() {
-    def ret= InternalHelper.safeCreate(this.delegate.upgrade(), io.vertx.core.http.ServerWebSocket.class, io.vertx.groovy.core.http.ServerWebSocket.class);
+    def ret= InternalHelper.safeCreate(this.delegate.upgrade(), io.vertx.groovy.core.http.ServerWebSocket.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/http/HttpServerRequestStream.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/HttpServerRequestStream.groovy
@@ -25,19 +25,19 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class HttpServerRequestStream implements ReadStream<HttpServerRequest> {
-  final def io.vertx.core.http.HttpServerRequestStream delegate;
-  public HttpServerRequestStream(io.vertx.core.http.HttpServerRequestStream delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.HttpServerRequestStream delegate;
+  public HttpServerRequestStream(Object delegate) {
+    this.delegate = (io.vertx.core.http.HttpServerRequestStream) delegate;
   }
   public Object getDelegate() {
     return delegate;
   }
   public HttpServerRequestStream exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerRequestStream) this.delegate).exceptionHandler(handler);
     return this;
   }
   public HttpServerRequestStream handler(Handler<HttpServerRequest> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.http.HttpServerRequest>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerRequestStream) this.delegate).handler(new Handler<io.vertx.core.http.HttpServerRequest>() {
       public void handle(io.vertx.core.http.HttpServerRequest event) {
         handler.handle(new io.vertx.groovy.core.http.HttpServerRequest(event));
       }
@@ -45,15 +45,15 @@ public class HttpServerRequestStream implements ReadStream<HttpServerRequest> {
     return this;
   }
   public HttpServerRequestStream pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerRequestStream) this.delegate).pause();
     return this;
   }
   public HttpServerRequestStream resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerRequestStream) this.delegate).resume();
     return this;
   }
   public HttpServerRequestStream endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerRequestStream) this.delegate).endHandler(endHandler);
     return this;
   }
 }

--- a/src/main/groovy/io/vertx/groovy/core/http/HttpServerResponse.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/HttpServerResponse.groovy
@@ -45,9 +45,9 @@ import io.vertx.groovy.core.Future
 */
 @CompileStatic
 public class HttpServerResponse implements WriteStream<Buffer> {
-  final def io.vertx.core.http.HttpServerResponse delegate;
-  public HttpServerResponse(io.vertx.core.http.HttpServerResponse delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.HttpServerResponse delegate;
+  public HttpServerResponse(Object delegate) {
+    this.delegate = (io.vertx.core.http.HttpServerResponse) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -61,19 +61,19 @@ public class HttpServerResponse implements WriteStream<Buffer> {
     return ret;
   }
   public HttpServerResponse exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerResponse) this.delegate).exceptionHandler(handler);
     return this;
   }
   public HttpServerResponse write(Buffer data) {
-    this.delegate.write((io.vertx.core.buffer.Buffer)data.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerResponse) this.delegate).write((io.vertx.core.buffer.Buffer)data.getDelegate());
     return this;
   }
   public HttpServerResponse setWriteQueueMaxSize(int maxSize) {
-    this.delegate.setWriteQueueMaxSize(maxSize);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerResponse) this.delegate).setWriteQueueMaxSize(maxSize);
     return this;
   }
   public HttpServerResponse drainHandler(Handler<Void> handler) {
-    this.delegate.drainHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.HttpServerResponse) this.delegate).drainHandler(handler);
     return this;
   }
   /**
@@ -147,7 +147,7 @@ public class HttpServerResponse implements WriteStream<Buffer> {
     if (cached_0 != null) {
       return cached_0;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.headers(), io.vertx.core.MultiMap.class, io.vertx.groovy.core.MultiMap.class);
+    def ret= InternalHelper.safeCreate(this.delegate.headers(), io.vertx.groovy.core.MultiMap.class);
     cached_0 = ret;
     return ret;
   }
@@ -169,7 +169,7 @@ public class HttpServerResponse implements WriteStream<Buffer> {
     if (cached_1 != null) {
       return cached_1;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.trailers(), io.vertx.core.MultiMap.class, io.vertx.groovy.core.MultiMap.class);
+    def ret= InternalHelper.safeCreate(this.delegate.trailers(), io.vertx.groovy.core.MultiMap.class);
     cached_1 = ret;
     return ret;
   }
@@ -298,9 +298,9 @@ public class HttpServerResponse implements WriteStream<Buffer> {
    * @param handler the handler
    * @return a reference to this, so the API can be used fluently
    */
-  public HttpServerResponse headersEndHandler(Handler<Future> handler) {
-    this.delegate.headersEndHandler(new Handler<io.vertx.core.Future>() {
-      public void handle(io.vertx.core.Future event) {
+  public HttpServerResponse headersEndHandler(Handler<Future<?>> handler) {
+    this.delegate.headersEndHandler(new Handler<io.vertx.core.Future<?>>() {
+      public void handle(io.vertx.core.Future<?> event) {
         handler.handle(new io.vertx.groovy.core.Future(event));
       }
     });

--- a/src/main/groovy/io/vertx/groovy/core/http/ServerWebSocket.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/ServerWebSocket.groovy
@@ -29,9 +29,9 @@ import io.vertx.groovy.core.net.SocketAddress
 */
 @CompileStatic
 public class ServerWebSocket implements WebSocketBase {
-  final def io.vertx.core.http.ServerWebSocket delegate;
-  public ServerWebSocket(io.vertx.core.http.ServerWebSocket delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.ServerWebSocket delegate;
+  public ServerWebSocket(Object delegate) {
+    this.delegate = (io.vertx.core.http.ServerWebSocket) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -84,7 +84,7 @@ public class ServerWebSocket implements WebSocketBase {
     if (cached_0 != null) {
       return cached_0;
     }
-    def ret= InternalHelper.safeCreate(((io.vertx.core.http.WebSocketBase) this.delegate).remoteAddress(), io.vertx.core.net.SocketAddress.class, io.vertx.groovy.core.net.SocketAddress.class);
+    def ret= InternalHelper.safeCreate(((io.vertx.core.http.WebSocketBase) this.delegate).remoteAddress(), io.vertx.groovy.core.net.SocketAddress.class);
     cached_0 = ret;
     return ret;
   }
@@ -96,16 +96,16 @@ public class ServerWebSocket implements WebSocketBase {
     if (cached_1 != null) {
       return cached_1;
     }
-    def ret= InternalHelper.safeCreate(((io.vertx.core.http.WebSocketBase) this.delegate).localAddress(), io.vertx.core.net.SocketAddress.class, io.vertx.groovy.core.net.SocketAddress.class);
+    def ret= InternalHelper.safeCreate(((io.vertx.core.http.WebSocketBase) this.delegate).localAddress(), io.vertx.groovy.core.net.SocketAddress.class);
     cached_1 = ret;
     return ret;
   }
   public ServerWebSocket exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).exceptionHandler(handler);
     return this;
   }
   public ServerWebSocket handler(Handler<Buffer> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.buffer.Buffer>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).handler(new Handler<io.vertx.core.buffer.Buffer>() {
       public void handle(io.vertx.core.buffer.Buffer event) {
         handler.handle(new io.vertx.groovy.core.buffer.Buffer(event));
       }
@@ -113,51 +113,51 @@ public class ServerWebSocket implements WebSocketBase {
     return this;
   }
   public ServerWebSocket pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).pause();
     return this;
   }
   public ServerWebSocket resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).resume();
     return this;
   }
   public ServerWebSocket endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).endHandler(endHandler);
     return this;
   }
   public ServerWebSocket write(Buffer data) {
-    this.delegate.write((io.vertx.core.buffer.Buffer)data.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).write((io.vertx.core.buffer.Buffer)data.getDelegate());
     return this;
   }
   public ServerWebSocket setWriteQueueMaxSize(int maxSize) {
-    this.delegate.setWriteQueueMaxSize(maxSize);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).setWriteQueueMaxSize(maxSize);
     return this;
   }
   public ServerWebSocket drainHandler(Handler<Void> handler) {
-    this.delegate.drainHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).drainHandler(handler);
     return this;
   }
   public ServerWebSocket writeFrame(WebSocketFrame frame) {
-    this.delegate.writeFrame((io.vertx.core.http.WebSocketFrame)frame.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).writeFrame((io.vertx.core.http.WebSocketFrame)frame.getDelegate());
     return this;
   }
   public ServerWebSocket writeFinalTextFrame(String text) {
-    this.delegate.writeFinalTextFrame(text);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).writeFinalTextFrame(text);
     return this;
   }
   public ServerWebSocket writeFinalBinaryFrame(Buffer data) {
-    this.delegate.writeFinalBinaryFrame((io.vertx.core.buffer.Buffer)data.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).writeFinalBinaryFrame((io.vertx.core.buffer.Buffer)data.getDelegate());
     return this;
   }
   public ServerWebSocket writeBinaryMessage(Buffer data) {
-    this.delegate.writeBinaryMessage((io.vertx.core.buffer.Buffer)data.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).writeBinaryMessage((io.vertx.core.buffer.Buffer)data.getDelegate());
     return this;
   }
   public ServerWebSocket closeHandler(Handler<Void> handler) {
-    this.delegate.closeHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).closeHandler(handler);
     return this;
   }
   public ServerWebSocket frameHandler(Handler<WebSocketFrame> handler) {
-    this.delegate.frameHandler(new Handler<io.vertx.core.http.WebSocketFrame>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.ServerWebSocket) this.delegate).frameHandler(new Handler<io.vertx.core.http.WebSocketFrame>() {
       public void handle(io.vertx.core.http.WebSocketFrame event) {
         handler.handle(new io.vertx.groovy.core.http.WebSocketFrame(event));
       }
@@ -192,7 +192,7 @@ public class ServerWebSocket implements WebSocketBase {
     if (cached_2 != null) {
       return cached_2;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.headers(), io.vertx.core.MultiMap.class, io.vertx.groovy.core.MultiMap.class);
+    def ret= InternalHelper.safeCreate(this.delegate.headers(), io.vertx.groovy.core.MultiMap.class);
     cached_2 = ret;
     return ret;
   }

--- a/src/main/groovy/io/vertx/groovy/core/http/ServerWebSocketStream.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/ServerWebSocketStream.groovy
@@ -25,19 +25,19 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class ServerWebSocketStream implements ReadStream<ServerWebSocket> {
-  final def io.vertx.core.http.ServerWebSocketStream delegate;
-  public ServerWebSocketStream(io.vertx.core.http.ServerWebSocketStream delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.ServerWebSocketStream delegate;
+  public ServerWebSocketStream(Object delegate) {
+    this.delegate = (io.vertx.core.http.ServerWebSocketStream) delegate;
   }
   public Object getDelegate() {
     return delegate;
   }
   public ServerWebSocketStream exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.StreamBase) this.delegate).exceptionHandler(handler);
     return this;
   }
   public ServerWebSocketStream handler(Handler<ServerWebSocket> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.http.ServerWebSocket>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.ReadStream) this.delegate).handler(new Handler<io.vertx.core.http.ServerWebSocket>() {
       public void handle(io.vertx.core.http.ServerWebSocket event) {
         handler.handle(new io.vertx.groovy.core.http.ServerWebSocket(event));
       }
@@ -45,15 +45,15 @@ public class ServerWebSocketStream implements ReadStream<ServerWebSocket> {
     return this;
   }
   public ServerWebSocketStream pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.ReadStream) this.delegate).pause();
     return this;
   }
   public ServerWebSocketStream resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.ReadStream) this.delegate).resume();
     return this;
   }
   public ServerWebSocketStream endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.ReadStream) this.delegate).endHandler(endHandler);
     return this;
   }
 }

--- a/src/main/groovy/io/vertx/groovy/core/http/WebSocket.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/WebSocket.groovy
@@ -25,9 +25,9 @@ import io.vertx.groovy.core.net.SocketAddress
 */
 @CompileStatic
 public class WebSocket implements WebSocketBase {
-  final def io.vertx.core.http.WebSocket delegate;
-  public WebSocket(io.vertx.core.http.WebSocket delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.WebSocket delegate;
+  public WebSocket(Object delegate) {
+    this.delegate = (io.vertx.core.http.WebSocket) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -80,7 +80,7 @@ public class WebSocket implements WebSocketBase {
     if (cached_0 != null) {
       return cached_0;
     }
-    def ret= InternalHelper.safeCreate(((io.vertx.core.http.WebSocketBase) this.delegate).remoteAddress(), io.vertx.core.net.SocketAddress.class, io.vertx.groovy.core.net.SocketAddress.class);
+    def ret= InternalHelper.safeCreate(((io.vertx.core.http.WebSocketBase) this.delegate).remoteAddress(), io.vertx.groovy.core.net.SocketAddress.class);
     cached_0 = ret;
     return ret;
   }
@@ -92,16 +92,16 @@ public class WebSocket implements WebSocketBase {
     if (cached_1 != null) {
       return cached_1;
     }
-    def ret= InternalHelper.safeCreate(((io.vertx.core.http.WebSocketBase) this.delegate).localAddress(), io.vertx.core.net.SocketAddress.class, io.vertx.groovy.core.net.SocketAddress.class);
+    def ret= InternalHelper.safeCreate(((io.vertx.core.http.WebSocketBase) this.delegate).localAddress(), io.vertx.groovy.core.net.SocketAddress.class);
     cached_1 = ret;
     return ret;
   }
   public WebSocket exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).exceptionHandler(handler);
     return this;
   }
   public WebSocket handler(Handler<Buffer> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.buffer.Buffer>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).handler(new Handler<io.vertx.core.buffer.Buffer>() {
       public void handle(io.vertx.core.buffer.Buffer event) {
         handler.handle(new io.vertx.groovy.core.buffer.Buffer(event));
       }
@@ -109,51 +109,51 @@ public class WebSocket implements WebSocketBase {
     return this;
   }
   public WebSocket pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).pause();
     return this;
   }
   public WebSocket resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).resume();
     return this;
   }
   public WebSocket endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).endHandler(endHandler);
     return this;
   }
   public WebSocket write(Buffer data) {
-    this.delegate.write((io.vertx.core.buffer.Buffer)data.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).write((io.vertx.core.buffer.Buffer)data.getDelegate());
     return this;
   }
   public WebSocket setWriteQueueMaxSize(int maxSize) {
-    this.delegate.setWriteQueueMaxSize(maxSize);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).setWriteQueueMaxSize(maxSize);
     return this;
   }
   public WebSocket drainHandler(Handler<Void> handler) {
-    this.delegate.drainHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).drainHandler(handler);
     return this;
   }
   public WebSocket writeFrame(WebSocketFrame frame) {
-    this.delegate.writeFrame((io.vertx.core.http.WebSocketFrame)frame.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).writeFrame((io.vertx.core.http.WebSocketFrame)frame.getDelegate());
     return this;
   }
   public WebSocket writeFinalTextFrame(String text) {
-    this.delegate.writeFinalTextFrame(text);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).writeFinalTextFrame(text);
     return this;
   }
   public WebSocket writeFinalBinaryFrame(Buffer data) {
-    this.delegate.writeFinalBinaryFrame((io.vertx.core.buffer.Buffer)data.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).writeFinalBinaryFrame((io.vertx.core.buffer.Buffer)data.getDelegate());
     return this;
   }
   public WebSocket writeBinaryMessage(Buffer data) {
-    this.delegate.writeBinaryMessage((io.vertx.core.buffer.Buffer)data.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).writeBinaryMessage((io.vertx.core.buffer.Buffer)data.getDelegate());
     return this;
   }
   public WebSocket closeHandler(Handler<Void> handler) {
-    this.delegate.closeHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).closeHandler(handler);
     return this;
   }
   public WebSocket frameHandler(Handler<WebSocketFrame> handler) {
-    this.delegate.frameHandler(new Handler<io.vertx.core.http.WebSocketFrame>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).frameHandler(new Handler<io.vertx.core.http.WebSocketFrame>() {
       public void handle(io.vertx.core.http.WebSocketFrame event) {
         handler.handle(new io.vertx.groovy.core.http.WebSocketFrame(event));
       }

--- a/src/main/groovy/io/vertx/groovy/core/http/WebSocketBase.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/WebSocketBase.groovy
@@ -55,9 +55,9 @@ public interface WebSocketBase extends ReadStream<Buffer>,  WriteStream<Buffer> 
 
 @CompileStatic
 class WebSocketBaseImpl implements WebSocketBase {
-  final def io.vertx.core.http.WebSocketBase delegate;
-  public WebSocketBaseImpl(io.vertx.core.http.WebSocketBase delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.WebSocketBase delegate;
+  public WebSocketBaseImpl(Object delegate) {
+    this.delegate = (io.vertx.core.http.WebSocketBase) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -71,11 +71,11 @@ class WebSocketBaseImpl implements WebSocketBase {
     return ret;
   }
   public WebSocketBase exceptionHandler(Handler<Throwable> handler) {
-    ((io.vertx.core.http.WebSocketBase) this.delegate).exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).exceptionHandler(handler);
     return this;
   }
   public WebSocketBase handler(Handler<Buffer> handler) {
-    ((io.vertx.core.http.WebSocketBase) this.delegate).handler(new Handler<io.vertx.core.buffer.Buffer>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).handler(new Handler<io.vertx.core.buffer.Buffer>() {
       public void handle(io.vertx.core.buffer.Buffer event) {
         handler.handle(new io.vertx.groovy.core.buffer.Buffer(event));
       }
@@ -83,27 +83,27 @@ class WebSocketBaseImpl implements WebSocketBase {
     return this;
   }
   public WebSocketBase pause() {
-    ((io.vertx.core.http.WebSocketBase) this.delegate).pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).pause();
     return this;
   }
   public WebSocketBase resume() {
-    ((io.vertx.core.http.WebSocketBase) this.delegate).resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).resume();
     return this;
   }
   public WebSocketBase endHandler(Handler<Void> endHandler) {
-    ((io.vertx.core.http.WebSocketBase) this.delegate).endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).endHandler(endHandler);
     return this;
   }
   public WebSocketBase write(Buffer data) {
-    ((io.vertx.core.http.WebSocketBase) this.delegate).write((io.vertx.core.buffer.Buffer)data.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).write((io.vertx.core.buffer.Buffer)data.getDelegate());
     return this;
   }
   public WebSocketBase setWriteQueueMaxSize(int maxSize) {
-    ((io.vertx.core.http.WebSocketBase) this.delegate).setWriteQueueMaxSize(maxSize);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).setWriteQueueMaxSize(maxSize);
     return this;
   }
   public WebSocketBase drainHandler(Handler<Void> handler) {
-    ((io.vertx.core.http.WebSocketBase) this.delegate).drainHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketBase) this.delegate).drainHandler(handler);
     return this;
   }
   /**
@@ -205,7 +205,7 @@ class WebSocketBaseImpl implements WebSocketBase {
     if (cached_0 != null) {
       return cached_0;
     }
-    def ret= InternalHelper.safeCreate(((io.vertx.core.http.WebSocketBase) this.delegate).remoteAddress(), io.vertx.core.net.SocketAddress.class, io.vertx.groovy.core.net.SocketAddress.class);
+    def ret= InternalHelper.safeCreate(((io.vertx.core.http.WebSocketBase) this.delegate).remoteAddress(), io.vertx.groovy.core.net.SocketAddress.class);
     cached_0 = ret;
     return ret;
   }
@@ -217,7 +217,7 @@ class WebSocketBaseImpl implements WebSocketBase {
     if (cached_1 != null) {
       return cached_1;
     }
-    def ret= InternalHelper.safeCreate(((io.vertx.core.http.WebSocketBase) this.delegate).localAddress(), io.vertx.core.net.SocketAddress.class, io.vertx.groovy.core.net.SocketAddress.class);
+    def ret= InternalHelper.safeCreate(((io.vertx.core.http.WebSocketBase) this.delegate).localAddress(), io.vertx.groovy.core.net.SocketAddress.class);
     cached_1 = ret;
     return ret;
   }

--- a/src/main/groovy/io/vertx/groovy/core/http/WebSocketFrame.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/WebSocketFrame.groovy
@@ -30,9 +30,9 @@ import io.vertx.groovy.core.buffer.Buffer
 */
 @CompileStatic
 public class WebSocketFrame {
-  final def io.vertx.core.http.WebSocketFrame delegate;
-  public WebSocketFrame(io.vertx.core.http.WebSocketFrame delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.WebSocketFrame delegate;
+  public WebSocketFrame(Object delegate) {
+    this.delegate = (io.vertx.core.http.WebSocketFrame) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -44,7 +44,7 @@ public class WebSocketFrame {
    * @return the frame
    */
   public static WebSocketFrame binaryFrame(Buffer data, boolean isFinal) {
-    def ret= InternalHelper.safeCreate(io.vertx.core.http.WebSocketFrame.binaryFrame((io.vertx.core.buffer.Buffer)data.getDelegate(), isFinal), io.vertx.core.http.WebSocketFrame.class, io.vertx.groovy.core.http.WebSocketFrame.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.http.WebSocketFrame.binaryFrame((io.vertx.core.buffer.Buffer)data.getDelegate(), isFinal), io.vertx.groovy.core.http.WebSocketFrame.class);
     return ret;
   }
   /**
@@ -54,7 +54,7 @@ public class WebSocketFrame {
    * @return the frame
    */
   public static WebSocketFrame textFrame(String str, boolean isFinal) {
-    def ret= InternalHelper.safeCreate(io.vertx.core.http.WebSocketFrame.textFrame(str, isFinal), io.vertx.core.http.WebSocketFrame.class, io.vertx.groovy.core.http.WebSocketFrame.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.http.WebSocketFrame.textFrame(str, isFinal), io.vertx.groovy.core.http.WebSocketFrame.class);
     return ret;
   }
   /**
@@ -64,7 +64,7 @@ public class WebSocketFrame {
    * @return the frame
    */
   public static WebSocketFrame continuationFrame(Buffer data, boolean isFinal) {
-    def ret= InternalHelper.safeCreate(io.vertx.core.http.WebSocketFrame.continuationFrame((io.vertx.core.buffer.Buffer)data.getDelegate(), isFinal), io.vertx.core.http.WebSocketFrame.class, io.vertx.groovy.core.http.WebSocketFrame.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.http.WebSocketFrame.continuationFrame((io.vertx.core.buffer.Buffer)data.getDelegate(), isFinal), io.vertx.groovy.core.http.WebSocketFrame.class);
     return ret;
   }
   /**
@@ -112,7 +112,7 @@ public class WebSocketFrame {
     if (cached_1 != null) {
       return cached_1;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.binaryData(), io.vertx.core.buffer.Buffer.class, io.vertx.groovy.core.buffer.Buffer.class);
+    def ret= InternalHelper.safeCreate(this.delegate.binaryData(), io.vertx.groovy.core.buffer.Buffer.class);
     cached_1 = ret;
     return ret;
   }

--- a/src/main/groovy/io/vertx/groovy/core/http/WebSocketStream.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/http/WebSocketStream.groovy
@@ -30,19 +30,19 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class WebSocketStream implements ReadStream<WebSocket> {
-  final def io.vertx.core.http.WebSocketStream delegate;
-  public WebSocketStream(io.vertx.core.http.WebSocketStream delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.http.WebSocketStream delegate;
+  public WebSocketStream(Object delegate) {
+    this.delegate = (io.vertx.core.http.WebSocketStream) delegate;
   }
   public Object getDelegate() {
     return delegate;
   }
   public WebSocketStream exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketStream) this.delegate).exceptionHandler(handler);
     return this;
   }
   public WebSocketStream handler(Handler<WebSocket> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.http.WebSocket>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketStream) this.delegate).handler(new Handler<io.vertx.core.http.WebSocket>() {
       public void handle(io.vertx.core.http.WebSocket event) {
         handler.handle(new io.vertx.groovy.core.http.WebSocket(event));
       }
@@ -50,15 +50,15 @@ public class WebSocketStream implements ReadStream<WebSocket> {
     return this;
   }
   public WebSocketStream pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketStream) this.delegate).pause();
     return this;
   }
   public WebSocketStream resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketStream) this.delegate).resume();
     return this;
   }
   public WebSocketStream endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.http.WebSocketStream) this.delegate).endHandler(endHandler);
     return this;
   }
 }

--- a/src/main/groovy/io/vertx/groovy/core/metrics/Measured.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/metrics/Measured.groovy
@@ -28,9 +28,9 @@ public interface Measured {
 
 @CompileStatic
 class MeasuredImpl implements Measured {
-  final def io.vertx.core.metrics.Measured delegate;
-  public MeasuredImpl(io.vertx.core.metrics.Measured delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.metrics.Measured delegate;
+  public MeasuredImpl(Object delegate) {
+    this.delegate = (io.vertx.core.metrics.Measured) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/net/NetClient.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/net/NetClient.groovy
@@ -30,9 +30,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class NetClient implements Measured {
-  final def io.vertx.core.net.NetClient delegate;
-  public NetClient(io.vertx.core.net.NetClient delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.net.NetClient delegate;
+  public NetClient(Object delegate) {
+    this.delegate = (io.vertx.core.net.NetClient) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/net/NetServer.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/net/NetServer.groovy
@@ -25,9 +25,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class NetServer implements Measured {
-  final def io.vertx.core.net.NetServer delegate;
-  public NetServer(io.vertx.core.net.NetServer delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.net.NetServer delegate;
+  public NetServer(Object delegate) {
+    this.delegate = (io.vertx.core.net.NetServer) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -47,7 +47,7 @@ public class NetServer implements Measured {
    * @return the connect stream
    */
   public NetSocketStream connectStream() {
-    def ret= InternalHelper.safeCreate(this.delegate.connectStream(), io.vertx.core.net.NetSocketStream.class, io.vertx.groovy.core.net.NetSocketStream.class);
+    def ret= InternalHelper.safeCreate(this.delegate.connectStream(), io.vertx.groovy.core.net.NetSocketStream.class);
     return ret;
   }
   /**
@@ -62,7 +62,7 @@ public class NetServer implements Measured {
       public void handle(io.vertx.core.net.NetSocket event) {
         handler.handle(new io.vertx.groovy.core.net.NetSocket(event));
       }
-    }), io.vertx.core.net.NetServer.class, io.vertx.groovy.core.net.NetServer.class);
+    }), io.vertx.groovy.core.net.NetServer.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/net/NetSocket.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/net/NetSocket.groovy
@@ -35,9 +35,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class NetSocket implements ReadStream<Buffer>,  WriteStream<Buffer> {
-  final def io.vertx.core.net.NetSocket delegate;
-  public NetSocket(io.vertx.core.net.NetSocket delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.net.NetSocket delegate;
+  public NetSocket(Object delegate) {
+    this.delegate = (io.vertx.core.net.NetSocket) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -51,11 +51,11 @@ public class NetSocket implements ReadStream<Buffer>,  WriteStream<Buffer> {
     return ret;
   }
   public NetSocket exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.WriteStream) this.delegate).exceptionHandler(handler);
     return this;
   }
   public NetSocket handler(Handler<Buffer> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.buffer.Buffer>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.ReadStream) this.delegate).handler(new Handler<io.vertx.core.buffer.Buffer>() {
       public void handle(io.vertx.core.buffer.Buffer event) {
         handler.handle(new io.vertx.groovy.core.buffer.Buffer(event));
       }
@@ -63,27 +63,27 @@ public class NetSocket implements ReadStream<Buffer>,  WriteStream<Buffer> {
     return this;
   }
   public NetSocket pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.ReadStream) this.delegate).pause();
     return this;
   }
   public NetSocket resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.ReadStream) this.delegate).resume();
     return this;
   }
   public NetSocket endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.ReadStream) this.delegate).endHandler(endHandler);
     return this;
   }
   public NetSocket write(Buffer data) {
-    this.delegate.write((io.vertx.core.buffer.Buffer)data.getDelegate());
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.WriteStream) this.delegate).write((io.vertx.core.buffer.Buffer)data.getDelegate());
     return this;
   }
   public NetSocket setWriteQueueMaxSize(int maxSize) {
-    this.delegate.setWriteQueueMaxSize(maxSize);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.WriteStream) this.delegate).setWriteQueueMaxSize(maxSize);
     return this;
   }
   public NetSocket drainHandler(Handler<Void> handler) {
-    this.delegate.drainHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.WriteStream) this.delegate).drainHandler(handler);
     return this;
   }
   /**
@@ -147,7 +147,7 @@ public class NetSocket implements ReadStream<Buffer>,  WriteStream<Buffer> {
     if (cached_0 != null) {
       return cached_0;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.remoteAddress(), io.vertx.core.net.SocketAddress.class, io.vertx.groovy.core.net.SocketAddress.class);
+    def ret= InternalHelper.safeCreate(this.delegate.remoteAddress(), io.vertx.groovy.core.net.SocketAddress.class);
     cached_0 = ret;
     return ret;
   }
@@ -159,7 +159,7 @@ public class NetSocket implements ReadStream<Buffer>,  WriteStream<Buffer> {
     if (cached_1 != null) {
       return cached_1;
     }
-    def ret= InternalHelper.safeCreate(this.delegate.localAddress(), io.vertx.core.net.SocketAddress.class, io.vertx.groovy.core.net.SocketAddress.class);
+    def ret= InternalHelper.safeCreate(this.delegate.localAddress(), io.vertx.groovy.core.net.SocketAddress.class);
     cached_1 = ret;
     return ret;
   }

--- a/src/main/groovy/io/vertx/groovy/core/net/NetSocketStream.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/net/NetSocketStream.groovy
@@ -25,19 +25,19 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class NetSocketStream implements ReadStream<NetSocket> {
-  final def io.vertx.core.net.NetSocketStream delegate;
-  public NetSocketStream(io.vertx.core.net.NetSocketStream delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.net.NetSocketStream delegate;
+  public NetSocketStream(Object delegate) {
+    this.delegate = (io.vertx.core.net.NetSocketStream) delegate;
   }
   public Object getDelegate() {
     return delegate;
   }
   public NetSocketStream exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.net.NetSocketStream) this.delegate).exceptionHandler(handler);
     return this;
   }
   public NetSocketStream handler(Handler<NetSocket> handler) {
-    this.delegate.handler(new Handler<io.vertx.core.net.NetSocket>() {
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.net.NetSocketStream) this.delegate).handler(new Handler<io.vertx.core.net.NetSocket>() {
       public void handle(io.vertx.core.net.NetSocket event) {
         handler.handle(new io.vertx.groovy.core.net.NetSocket(event));
       }
@@ -45,15 +45,15 @@ public class NetSocketStream implements ReadStream<NetSocket> {
     return this;
   }
   public NetSocketStream pause() {
-    this.delegate.pause();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.net.NetSocketStream) this.delegate).pause();
     return this;
   }
   public NetSocketStream resume() {
-    this.delegate.resume();
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.net.NetSocketStream) this.delegate).resume();
     return this;
   }
   public NetSocketStream endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.net.NetSocketStream) this.delegate).endHandler(endHandler);
     return this;
   }
 }

--- a/src/main/groovy/io/vertx/groovy/core/net/SocketAddress.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/net/SocketAddress.groovy
@@ -22,9 +22,9 @@ import io.vertx.lang.groovy.InternalHelper
 */
 @CompileStatic
 public class SocketAddress {
-  final def io.vertx.core.net.SocketAddress delegate;
-  public SocketAddress(io.vertx.core.net.SocketAddress delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.net.SocketAddress delegate;
+  public SocketAddress(Object delegate) {
+    this.delegate = (io.vertx.core.net.SocketAddress) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/parsetools/RecordParser.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/parsetools/RecordParser.groovy
@@ -52,9 +52,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class RecordParser implements Handler<Buffer> {
-  final def io.vertx.core.parsetools.RecordParser delegate;
-  public RecordParser(io.vertx.core.parsetools.RecordParser delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.parsetools.RecordParser delegate;
+  public RecordParser(Object delegate) {
+    this.delegate = (io.vertx.core.parsetools.RecordParser) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -80,7 +80,7 @@ public class RecordParser implements Handler<Buffer> {
       public void handle(io.vertx.core.buffer.Buffer event) {
         output.handle(new io.vertx.groovy.core.buffer.Buffer(event));
       }
-    }), io.vertx.core.parsetools.RecordParser.class, io.vertx.groovy.core.parsetools.RecordParser.class);
+    }), io.vertx.groovy.core.parsetools.RecordParser.class);
     return ret;
   }
   /**
@@ -97,7 +97,7 @@ public class RecordParser implements Handler<Buffer> {
       public void handle(io.vertx.core.buffer.Buffer event) {
         output.handle(new io.vertx.groovy.core.buffer.Buffer(event));
       }
-    }), io.vertx.core.parsetools.RecordParser.class, io.vertx.groovy.core.parsetools.RecordParser.class);
+    }), io.vertx.groovy.core.parsetools.RecordParser.class);
     return ret;
   }
   /**
@@ -114,7 +114,7 @@ public class RecordParser implements Handler<Buffer> {
       public void handle(io.vertx.core.buffer.Buffer event) {
         output.handle(new io.vertx.groovy.core.buffer.Buffer(event));
       }
-    }), io.vertx.core.parsetools.RecordParser.class, io.vertx.groovy.core.parsetools.RecordParser.class);
+    }), io.vertx.groovy.core.parsetools.RecordParser.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/shareddata/AsyncMap.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/shareddata/AsyncMap.groovy
@@ -25,9 +25,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class AsyncMap<K,V> {
-  final def io.vertx.core.shareddata.AsyncMap delegate;
-  public AsyncMap(io.vertx.core.shareddata.AsyncMap delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.shareddata.AsyncMap delegate;
+  public AsyncMap(Object delegate) {
+    this.delegate = (io.vertx.core.shareddata.AsyncMap) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/shareddata/Counter.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/shareddata/Counter.groovy
@@ -25,9 +25,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class Counter {
-  final def io.vertx.core.shareddata.Counter delegate;
-  public Counter(io.vertx.core.shareddata.Counter delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.shareddata.Counter delegate;
+  public Counter(Object delegate) {
+    this.delegate = (io.vertx.core.shareddata.Counter) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/shareddata/LocalMap.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/shareddata/LocalMap.groovy
@@ -28,9 +28,9 @@ import io.vertx.lang.groovy.InternalHelper
 */
 @CompileStatic
 public class LocalMap<K,V> {
-  final def io.vertx.core.shareddata.LocalMap delegate;
-  public LocalMap(io.vertx.core.shareddata.LocalMap delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.shareddata.LocalMap delegate;
+  public LocalMap(Object delegate) {
+    this.delegate = (io.vertx.core.shareddata.LocalMap) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/shareddata/Lock.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/shareddata/Lock.groovy
@@ -25,9 +25,9 @@ import io.vertx.lang.groovy.InternalHelper
 */
 @CompileStatic
 public class Lock {
-  final def io.vertx.core.shareddata.Lock delegate;
-  public Lock(io.vertx.core.shareddata.Lock delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.shareddata.Lock delegate;
+  public Lock(Object delegate) {
+    this.delegate = (io.vertx.core.shareddata.Lock) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/shareddata/SharedData.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/shareddata/SharedData.groovy
@@ -34,9 +34,9 @@ import io.vertx.core.Handler
 */
 @CompileStatic
 public class SharedData {
-  final def io.vertx.core.shareddata.SharedData delegate;
-  public SharedData(io.vertx.core.shareddata.SharedData delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.shareddata.SharedData delegate;
+  public SharedData(Object delegate) {
+    this.delegate = (io.vertx.core.shareddata.SharedData) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -122,7 +122,7 @@ public class SharedData {
    * @return the msp
    */
   public <K, V> LocalMap<K,V> getLocalMap(String name) {
-    def ret= InternalHelper.safeCreate(this.delegate.getLocalMap(name), io.vertx.core.shareddata.LocalMap.class, io.vertx.groovy.core.shareddata.LocalMap.class);
+    def ret= InternalHelper.safeCreate(this.delegate.getLocalMap(name), io.vertx.groovy.core.shareddata.LocalMap.class);
     return ret;
   }
 }

--- a/src/main/groovy/io/vertx/groovy/core/streams/Pump.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/streams/Pump.groovy
@@ -39,9 +39,9 @@ import io.vertx.lang.groovy.InternalHelper
 */
 @CompileStatic
 public class Pump {
-  final def io.vertx.core.streams.Pump delegate;
-  public Pump(io.vertx.core.streams.Pump delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.streams.Pump delegate;
+  public Pump(Object delegate) {
+    this.delegate = (io.vertx.core.streams.Pump) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -53,7 +53,7 @@ public class Pump {
    * @return the pump
    */
   public static <T> Pump pump(ReadStream<T> rs, WriteStream<T> ws) {
-    def ret= InternalHelper.safeCreate(io.vertx.core.streams.Pump.pump((io.vertx.core.streams.ReadStream<T>)rs.getDelegate(), (io.vertx.core.streams.WriteStream<T>)ws.getDelegate()), io.vertx.core.streams.Pump.class, io.vertx.groovy.core.streams.Pump.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.streams.Pump.pump((io.vertx.core.streams.ReadStream<T>)rs.getDelegate(), (io.vertx.core.streams.WriteStream<T>)ws.getDelegate()), io.vertx.groovy.core.streams.Pump.class);
     return ret;
   }
   /**
@@ -65,7 +65,7 @@ public class Pump {
    * @return the pump
    */
   public static <T> Pump pump(ReadStream<T> rs, WriteStream<T> ws, int writeQueueMaxSize) {
-    def ret= InternalHelper.safeCreate(io.vertx.core.streams.Pump.pump((io.vertx.core.streams.ReadStream<T>)rs.getDelegate(), (io.vertx.core.streams.WriteStream<T>)ws.getDelegate(), writeQueueMaxSize), io.vertx.core.streams.Pump.class, io.vertx.groovy.core.streams.Pump.class);
+    def ret= InternalHelper.safeCreate(io.vertx.core.streams.Pump.pump((io.vertx.core.streams.ReadStream<T>)rs.getDelegate(), (io.vertx.core.streams.WriteStream<T>)ws.getDelegate(), writeQueueMaxSize), io.vertx.groovy.core.streams.Pump.class);
     return ret;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/streams/ReadStream.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/streams/ReadStream.groovy
@@ -36,9 +36,9 @@ public interface ReadStream<T> extends StreamBase {
 
 @CompileStatic
 class ReadStreamImpl<T> implements ReadStream<T> {
-  final def io.vertx.core.streams.ReadStream delegate;
-  public ReadStreamImpl(io.vertx.core.streams.ReadStream delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.streams.ReadStream delegate;
+  public ReadStreamImpl(Object delegate) {
+    this.delegate = (io.vertx.core.streams.ReadStream) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -49,7 +49,7 @@ class ReadStreamImpl<T> implements ReadStream<T> {
    * @return a reference to this, so the API can be used fluently
    */
   public ReadStream<T> exceptionHandler(Handler<Throwable> handler) {
-    ((io.vertx.core.streams.ReadStream) this.delegate).exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.StreamBase) this.delegate).exceptionHandler(handler);
     return this;
   }
   /**

--- a/src/main/groovy/io/vertx/groovy/core/streams/StreamBase.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/streams/StreamBase.groovy
@@ -29,9 +29,9 @@ public interface StreamBase {
 
 @CompileStatic
 class StreamBaseImpl implements StreamBase {
-  final def io.vertx.core.streams.StreamBase delegate;
-  public StreamBaseImpl(io.vertx.core.streams.StreamBase delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.streams.StreamBase delegate;
+  public StreamBaseImpl(Object delegate) {
+    this.delegate = (io.vertx.core.streams.StreamBase) delegate;
   }
   public Object getDelegate() {
     return delegate;

--- a/src/main/groovy/io/vertx/groovy/core/streams/WriteStream.groovy
+++ b/src/main/groovy/io/vertx/groovy/core/streams/WriteStream.groovy
@@ -37,9 +37,9 @@ public interface WriteStream<T> extends StreamBase {
 
 @CompileStatic
 class WriteStreamImpl<T> implements WriteStream<T> {
-  final def io.vertx.core.streams.WriteStream delegate;
-  public WriteStreamImpl(io.vertx.core.streams.WriteStream delegate) {
-    this.delegate = delegate;
+  private final def io.vertx.core.streams.WriteStream delegate;
+  public WriteStreamImpl(Object delegate) {
+    this.delegate = (io.vertx.core.streams.WriteStream) delegate;
   }
   public Object getDelegate() {
     return delegate;
@@ -50,7 +50,7 @@ class WriteStreamImpl<T> implements WriteStream<T> {
    * @return a reference to this, so the API can be used fluently
    */
   public WriteStream<T> exceptionHandler(Handler<Throwable> handler) {
-    ((io.vertx.core.streams.WriteStream) this.delegate).exceptionHandler(handler);
+    ( /* Work around for https://jira.codehaus.org/browse/GROOVY-6970 */ (io.vertx.core.streams.WriteStream) this.delegate).exceptionHandler(handler);
     return this;
   }
   /**

--- a/src/main/groovy/io/vertx/lang/groovy/InternalHelper.groovy
+++ b/src/main/groovy/io/vertx/lang/groovy/InternalHelper.groovy
@@ -67,9 +67,9 @@ public class InternalHelper {
     return Future.failedFuture(t);
   }
 
-  public static <T, D> T safeCreate(D delegate, Class<D> delegateType, Class<T> type) {
+  public static <T, D> T safeCreate(D delegate, Class<T> type) {
     if (delegate != null) {
-      Constructor<T> ctor = type.getConstructor(delegateType)
+      Constructor<T> ctor = type.getConstructor(Object.class)
       return ctor.newInstance(delegate)
     }
     return null

--- a/src/main/java/io/vertx/lang/groovy/GroovyDocGenerator.java
+++ b/src/main/java/io/vertx/lang/groovy/GroovyDocGenerator.java
@@ -55,7 +55,7 @@ public class GroovyDocGenerator implements DocGenerator {
     try {
       type = factory.create(elt.asType());
     } catch (Exception e) {
-      System.out.println("Could not resolve doc likn for type " + elt.getQualifiedName());
+      System.out.println("Could not resolve doc link for type " + elt.getQualifiedName());
       return null;
     }
     if (type.getKind() == ClassKind.DATA_OBJECT) {

--- a/src/main/resources/vertx-groovy/template/classbody.templ
+++ b/src/main/resources/vertx-groovy/template/classbody.templ
@@ -1,9 +1,9 @@
-	  final def @{type.raw} delegate;\n
-	  public @{constructor}(@{type.raw} delegate) {\n
+	  private final def @{type.raw} delegate;\n
+	  public @{constructor}(Object delegate) {\n
 	@if{concrete && concreteSuperTypes.size() > 0}
-	    super(delegate);\n
+	    super((@{type.raw}) delegate);\n
 	@end{}
-	    this.delegate = delegate;\n
+	    this.delegate = (@{type.raw}) delegate;\n
 	  }\n
 
 	  public Object getDelegate() {\n
@@ -86,7 +86,7 @@
 		    def ret = @includeNamed{'invokeDelegate';method=method};\n
 		@else{method.returnType.kind == CLASS_API}
 			@code{cachedType=method.returnType.simpleName}
-		    def ret= InternalHelper.safeCreate(@includeNamed{'invokeDelegate';method=method}, @{method.returnType.raw}.class, @{genConstructorType(method.returnType.raw)}.class);\n
+		    def ret= InternalHelper.safeCreate(@includeNamed{'invokeDelegate';method=method}, @{genConstructorType(method.returnType.raw)}.class);\n
 		@else{}
 			@code{cachedType=method.returnType.name}
 		    def ret = @includeNamed{'invokeDelegate';method=method};\n

--- a/src/test/java/META-INF/MANIFEST.MF
+++ b/src/test/java/META-INF/MANIFEST.MF
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 Archiver-Version: Plexus Archiver
-Created-By: 25.45-b02 (Oracle Corporation)
+Created-By: 25.20-b05 (Oracle Corporation)
 


### PR DESCRIPTION
Fix #13.

To hide the broken link we decided to make the property private (as it should not be used anyway). So the constructor receives an Object casted in the constructor. So, it also changes the InternalHelper constructor call to find the right constructor (and remove the useless parameter).