### PR TITLE
don't configure when properties size is zero

### DIFF
--- a/src/main/groovy/io/vertx/lang/groovy/GroovyVerticleFactory.groovy
+++ b/src/main/groovy/io/vertx/lang/groovy/GroovyVerticleFactory.groovy
@@ -129,7 +129,10 @@ public class GroovyVerticleFactory implements VerticleFactory {
     }
 
     CompilerConfiguration compilerCfg = new CompilerConfiguration(CompilerConfiguration.DEFAULT);
-    compilerCfg.configure(properties);
+    if(properties.size() != 0){
+        compilerCfg.configure(properties);
+    }
+
     if (customizer != null) {
       Object result = customizer.call(compilerCfg);
       // Expectation: If result isn't a CompilerConfiguration, the original one has been modified


### PR DESCRIPTION
when properties size is zero. this code ` compilerCfg.configure(properties)` will set compilerCfg.sourceEncoding to 'US-ASCII',and if the groovy file contains other encode chars,it will go wrong.  But the default compilerCfg.sourceEncoding is the real file encoding. So,I suggest we can check properties size first before use it configure. 