### PR TITLE
Update Groovy (Vert.x 4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,21 +59,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-docgen</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-codetrans</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-codegen</artifactId>
-      <scope>provided</scope>
       <classifier>sources</classifier>
     </dependency>
     <dependency>
@@ -403,11 +388,6 @@
     <!-- What we need at runtime -->
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy</artifactId>
-      <version>${groovy.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-json</artifactId>
       <version>${groovy.version}</version>
     </dependency>
@@ -422,12 +402,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-service-proxy</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <groovy.version>3.0.0</groovy.version>
+    <groovy.version>3.0.1</groovy.version>
     <asciidoc.path>/groovy</asciidoc.path>
     <graphql.java.major.version>14</graphql.java.major.version>
     <graphql.java.version>${graphql.java.major.version}.0</graphql.java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-core</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -132,11 +132,6 @@
 
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <optional>true</optional>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <groovy.version>3.0.0-rc-3</groovy.version>
+    <groovy.version>3.0.0</groovy.version>
     <asciidoc.path>/groovy</asciidoc.path>
     <graphql.java.major.version>14</graphql.java.major.version>
     <graphql.java.version>${graphql.java.major.version}.0</graphql.java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <groovy.version>3.0.0-rc-1</groovy.version>
+    <groovy.version>3.0.0-rc-3</groovy.version>
     <asciidoc.path>/groovy</asciidoc.path>
     <graphql.java.major.version>14</graphql.java.major.version>
     <graphql.java.version>${graphql.java.major.version}.0</graphql.java.version>


### PR DESCRIPTION
Groovy 3.0.0 is released (https://twitter.com/paulk_asert/status/1226866079600799744). I've been trying to do a PR with a no error build since RC2, but I always get the following exception in Travis:

```io.vertx.docgen.DocGenException: Could not resolve io.vertx.core.http.HttpServer#websocketHandler(io.vertx.core.Handler)```

So far I couldn't identify where the call to websocketHandler comes from. In vertx-core master branch the correct one now is webSocketHandler.

I'm sorry, but it's as far as I could go... I also removed some duplicated dependecies as Travis was complaining about them.