### PR TITLE
Upgrade Groovy (3.9 branch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <stack.version>3.9.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <groovy.version>2.5.8</groovy.version>
+    <groovy.version>3.0.0</groovy.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <stack.version>3.8.1-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <groovy.version>2.5.6</groovy.version>
+    <groovy.version>2.5.8</groovy.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <stack.version>3.9.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <groovy.version>3.0.0</groovy.version>
+    <groovy.version>3.0.1</groovy.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <stack.version>3.9.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <groovy.version>3.0.1</groovy.version>
+    <groovy.version>3.0.2</groovy.version>
   </properties>
 
   <dependencyManagement>

--- a/vertx-lang-groovy-gen/pom.xml
+++ b/vertx-lang-groovy-gen/pom.xml
@@ -172,12 +172,12 @@
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
-        <version>1.5</version>
+        <version>1.7.1</version>
         <executions>
           <execution>
             <goals>
               <goal>addTestSources</goal>
-              <goal>testCompile</goal>
+              <goal>compileTests</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Groovy 3.0.0 final was released (https://groovy-lang.org/releasenotes/groovy-3.0.html).

Branch 3.8 has been using Groovy 2.5.x, but now that a 3.9 branch came up (aiming Vert.x 4), it seems more reasonable to move Groovy version to the new one.

Please consider merging this PR. I'll close https://github.com/vert-x3/vertx-lang-groovy/pull/88 if favor of this one.