### PR TITLE
Revert "Update Groovy (Vert.x 4)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <groovy.version>3.0.4</groovy.version>
+    <groovy.version>3.0.3</groovy.version>
     <asciidoc.path>/groovy</asciidoc.path>
     <graphql.java.major.version>14</graphql.java.major.version>
     <graphql.java.version>${graphql.java.major.version}.0</graphql.java.version>


### PR DESCRIPTION
Reverts vert-x3/vertx-lang-groovy#101

it seems that this brings testng 7.2.0 that is not in Maven Central