### PR TITLE
Revert "Update Groovy (Vert.x 3.9)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <stack.version>3.9.2-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <groovy.version>3.0.3</groovy.version>
+    <groovy.version>3.0.2</groovy.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <stack.version>3.9.2-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <groovy.version>3.0.4</groovy.version>
+    <groovy.version>3.0.3</groovy.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Reverts vert-x3/vertx-lang-groovy#100

it seems that this brings testng 7.2.0 that is not in Maven Central