### PR TITLE
Update ScriptVerticle. Replace Future with Promise

### DIFF
--- a/vertx-lang-groovy-gen/src/main/java/io/vertx/lang/groovy/GroovyVerticle.java
+++ b/vertx-lang-groovy-gen/src/main/java/io/vertx/lang/groovy/GroovyVerticle.java
@@ -17,7 +17,7 @@ package io.vertx.lang.groovy;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
 
@@ -58,9 +58,9 @@ public class GroovyVerticle {
    *
    * @param startFuture  the future
    */
-  public void start(Future<Void> startFuture) throws Exception {
+  public void start(Promise<Void> startPromise) throws Exception {
     start();
-    startFuture.complete();
+    startPromise.complete();
   }
 
   /**
@@ -73,9 +73,9 @@ public class GroovyVerticle {
    *
    * @param stopFuture  the future
    */
-  public void stop(Future<Void> stopFuture) throws Exception {
+  public void stop(Promise<Void> stopPromise) throws Exception {
     stop();
-    stopFuture.complete();
+    stopPromise.complete();
   }
 
   /**
@@ -85,15 +85,15 @@ public class GroovyVerticle {
     return new AbstractVerticle() {
 
       @Override
-      public void start(Future<Void> startFuture) throws Exception {
+      public void start(Promise<Void> startPromise) throws Exception {
         GroovyVerticle.this.vertx = super.vertx;
         GroovyVerticle.this.context = super.context;
-        GroovyVerticle.this.start(startFuture);
+        GroovyVerticle.this.start(startPromise);
       }
 
       @Override
-      public void stop(Future<Void> stopFuture) throws Exception {
-        GroovyVerticle.this.stop(stopFuture);
+      public void stop(Promise<Void> stopPromise) throws Exception {
+        GroovyVerticle.this.stop(stopPromise);
       }
     };
   }

--- a/vertx-lang-groovy-gen/src/test/resources/io/vertx/lang/groovy/LifeCycleAsyncVerticleClass.groovy
+++ b/vertx-lang-groovy-gen/src/test/resources/io/vertx/lang/groovy/LifeCycleAsyncVerticleClass.groovy
@@ -35,7 +35,7 @@ public class LifeCycleAsyncVerticleClass extends GroovyVerticle {
   void stop(Promise<Void> stopPromise) throws Exception {
     vertx.timerStream(200).handler({ id ->
       System.setProperty("stopped", "true");
-      stopFuture.complete()
+      stopPromise.complete()
     });
   }
 }

--- a/vertx-lang-groovy-gen/src/test/resources/io/vertx/lang/groovy/LifeCycleAsyncVerticleClass.groovy
+++ b/vertx-lang-groovy-gen/src/test/resources/io/vertx/lang/groovy/LifeCycleAsyncVerticleClass.groovy
@@ -16,7 +16,7 @@
 
 package io.vertx.lang.groovy
 
-import io.vertx.core.Future
+import io.vertx.core.Promise
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -24,15 +24,15 @@ import io.vertx.core.Future
 public class LifeCycleAsyncVerticleClass extends GroovyVerticle {
 
   @Override
-  void start(Future<Void> startFuture) throws Exception {
+  void start(Promise<Void> startPromise) throws Exception {
     vertx.timerStream(200).handler({ id ->
       System.setProperty("started", "true");
-      startFuture.complete()
+      startPromise.complete()
     });
   }
 
   @Override
-  void stop(Future<Void> stopFuture) throws Exception {
+  void stop(Promise<Void> stopPromise) throws Exception {
     vertx.timerStream(200).handler({ id ->
       System.setProperty("stopped", "true");
       stopFuture.complete()

--- a/vertx-lang-groovy-gen/src/test/resources/io/vertx/lang/groovy/LifeCycleAsyncVerticleScript.groovy
+++ b/vertx-lang-groovy-gen/src/test/resources/io/vertx/lang/groovy/LifeCycleAsyncVerticleScript.groovy
@@ -16,14 +16,14 @@
 
 package io.vertx.lang.groovy
 
-import io.vertx.groovy.core.Future
+import io.vertx.core.Promise
 
-void vertxStart(Future start) {
+void vertxStart(Promise start) {
   System.setProperty("started", "true");
   start.complete()
 }
 
-void vertxStop(Future stop) {
+void vertxStop(Promise stop) {
   System.setProperty("stopped", "true");
   stop.complete()
 }

--- a/vertx-lang-groovy/src/test/resources/unit/verticle/exceptionHandler.groovy
+++ b/vertx-lang-groovy/src/test/resources/unit/verticle/exceptionHandler.groovy
@@ -1,9 +1,9 @@
 package verticle
 
-import io.vertx.core.Future
+import io.vertx.core.Promise
 import io.vertx.ext.unit.TestSuite
 
-def vertxStart(Future future) {
+def vertxStart(Promise promise) {
   def suite = TestSuite.create("my_suite").beforeEach({ context ->
     vertx.exceptionHandler(context.exceptionHandler())
   }).test "timer_test", { context ->
@@ -12,5 +12,5 @@ def vertxStart(Future future) {
       throw new AssertionError("the_failure")
     }
   }
-  suite.run().resolve((Future)future)
+  suite.run().resolve((Promise)promise)
 }

--- a/vertx-lang-groovy/src/test/resources/unit/verticle/failing.groovy
+++ b/vertx-lang-groovy/src/test/resources/unit/verticle/failing.groovy
@@ -10,5 +10,5 @@ def vertxStart(Promise promise) {
       context.fail(new Exception("the_failure"))
     }
   }
-  suite.run().resolve(promise)
+  suite.run().resolve((Promise)promise)
 }

--- a/vertx-lang-groovy/src/test/resources/unit/verticle/failing.groovy
+++ b/vertx-lang-groovy/src/test/resources/unit/verticle/failing.groovy
@@ -1,14 +1,14 @@
 package verticle
 
-import io.vertx.core.Future
+import io.vertx.core.Promise
 import io.vertx.ext.unit.TestSuite
 
-def vertxStart(Future future) {
+def vertxStart(Promise promise) {
   def suite = TestSuite.create("my_suite").test "timer_test", { context ->
     def async = context.async()
     vertx.setTimer 50, {
       context.fail(new Exception("the_failure"))
     }
   }
-  suite.run().resolve((Future)future)
+  suite.run().resolve(promise)
 }

--- a/vertx-lang-groovy/src/test/resources/unit/verticle/timer.groovy
+++ b/vertx-lang-groovy/src/test/resources/unit/verticle/timer.groovy
@@ -1,14 +1,14 @@
 package verticle
 
-import io.vertx.core.Future
+import io.vertx.core.Promise
 import io.vertx.ext.unit.TestSuite
 
-def vertxStart(Future future) {
+def vertxStart(Promise promise) {
   def suite = TestSuite.create("my_suite").test "timer_test", { context ->
     def async = context.async()
     vertx.setTimer 50, {
       async.complete()
     }
   }
-  suite.run().resolve((Future)future);
+  suite.run().resolve((Promise)promise);
 }


### PR DESCRIPTION
ScriptVerticle in 3.9 is still using Future, while 4.0 is already using Promise. Not sure if this will fix #113, but either way the change is needed.