### PR TITLE
Fix FreeMarkerGroovyTemplateTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,23 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.14.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -120,7 +136,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.3.0</version>
+      <version>3.27.7</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/test/groovy/io/vertx/groovy/web/FreeMarkerGroovyTemplateTest.groovy
+++ b/src/test/groovy/io/vertx/groovy/web/FreeMarkerGroovyTemplateTest.groovy
@@ -17,11 +17,10 @@
 package io.vertx.groovy.web
 
 import io.vertx.core.http.HttpMethod
-import io.vertx.ext.web.tests.WebTestBase
 import io.vertx.ext.web.handler.TemplateHandler
 import io.vertx.ext.web.templ.freemarker.FreeMarkerTemplateEngine
-import org.junit.Assume
-import org.junit.Test
+import io.vertx.ext.web.tests.WebTestBase
+import org.junit.jupiter.api.Test
 
 /**
  * @author Thomas Segismont
@@ -30,7 +29,6 @@ class FreeMarkerGroovyTemplateTest extends WebTestBase {
 
   @Test
   void testTemplateHandler() throws Exception {
-    Assume.assumeFalse(System.getProperty("java.version").startsWith("9"));
     def engine = FreeMarkerTemplateEngine.create(vertx)
     router.route().handler({ context ->
       def ctx = [:]


### PR DESCRIPTION
WebTestBase relies on JUnit5 now.
So the POM file must be configured for a mix of JUnit4 and JUnit5 tests, and the imports changed in FreeMarkerGroovyTemplateTest

In addition to this, bumped JUnit4 and AssertJ versions.